### PR TITLE
when set_ticket is called the cached address to the handoff directory should ideally be cleared too

### DIFF
--- a/src/client/tactic_client_lib/tactic_server_stub.py
+++ b/src/client/tactic_client_lib/tactic_server_stub.py
@@ -132,6 +132,10 @@ class TacticServerStub(object):
         '''set the login ticket'''
         my.set_login_ticket(ticket)
 
+        # reset the handoff_dir
+        my.handoff_dir = None
+
+
     def set_login_ticket(my, ticket):
         '''Function: set_login_ticket(ticket)
            Set the login ticket with the ticket key'''


### PR DESCRIPTION
when set_ticket is called the cached address to the handoff directory (handoff_dir) should be cleared (None)

Minor change:

code line broken at 80 characters for better readability and conformance with PEP8
