### PR TITLE
BRANCH SP-814:

### DIFF
--- a/src/pyasm/biz/expression.py
+++ b/src/pyasm/biz/expression.py
@@ -1245,8 +1245,10 @@ class MethodMode(ExpressionParser):
                 first_arg = args[0]
                 if my.sobjects:
                     sobject = my.sobjects[0]
-                    cmd = PythonCmd(script_path=first_arg, sobject=sobject)
-                    results = cmd.execute()
+                else:
+                    sobject = None
+                cmd = PythonCmd(script_path=first_arg, sobject=sobject)
+                results = cmd.execute()
 
 
         elif method == 'SUM':


### PR DESCRIPTION
   allowed @PYTHON to run without a passed-in sobject
