### PR TITLE
Fixed a bug in the client API get_output_tasks()

### DIFF
--- a/src/client/tactic_client_lib/tactic_server_stub.py
+++ b/src/client/tactic_client_lib/tactic_server_stub.py
@@ -2859,7 +2859,7 @@ class TacticServerStub(object):
         @return:
         list of output tasks
         '''
-        return my.server.get_input_tasks(my.ticket, search_key)
+        return my.server.get_output_tasks(my.ticket, search_key)
 
 
 


### PR DESCRIPTION
Fixed a bug in the client API where get_output_tasks() was returning input tasks instead.
