### PR TITLE
BRANCH SP-1223:

### DIFF
--- a/src/client/test/client_api_test.py
+++ b/src/client/test/client_api_test.py
@@ -756,6 +756,8 @@ class ClientApiTest(unittest.TestCase):
         # do another checkin, but leaving a breadcrumb
         my.server.upload_file(file_path)
         result = my.server.simple_checkin(search_key, context, file_path, file_type="foo", is_current=False, breadcrumb=True)
+
+        
         breadcrumb_file = "%s.snapshot" % file_path
         my.assertEquals( True, os.path.exists(file_path) )
         # remove it
@@ -1034,6 +1036,9 @@ class ClientApiTest(unittest.TestCase):
         if not linux_client_repo_dir:
             linux_client_repo_dir = base_dirs.get('asset_base_dir')
 
+        if isinstance(linux_client_repo_dir, dict):
+            linux_client_repo_dir = linux_client_repo_dir.get('default')
+
         my.assertEquals(1, len(dep_snapshots))
         my.assertEquals(2, len(paths))
 
@@ -1044,6 +1049,8 @@ class ClientApiTest(unittest.TestCase):
 
         paths = dep_snapshots[0].get('__paths__')
         web_base_dir = base_dirs.get('web_base_dir')
+        if isinstance(web_base_dir, dict):
+            web_base_dir = web_base_dir.get('default')
         for path in paths:
             my.assertEquals(path.startswith('%s/unittest/person/'%web_base_dir), True)
     
@@ -1536,9 +1543,8 @@ class ClientApiTest(unittest.TestCase):
         columns = ['code']
         children = my.server.get_all_children(country_key, child_type, columns=columns)
         child = children[0]
-
-        # code and __search_key__
-        my.assertEquals(2, len(child.keys() ) )
+        # code, __search_type__,  and __search_key__
+        my.assertEquals(3, len(child.keys() ) )
 
         # test setting parent
         data = { 'code': 'calgary' }

--- a/src/pyasm/biz/biz_test.py
+++ b/src/pyasm/biz/biz_test.py
@@ -214,7 +214,6 @@ class BizTest(unittest.TestCase):
             file = open(my.file_path, 'w')
             file.write("whatever")
             file.close()
-
             # check in 2 current revisions
             checkin = FileCheckin(my.person, my.file_path, "main", context=my.context, is_revision=True, is_current=True)
             checkin.execute()
@@ -470,7 +469,6 @@ class BizTest(unittest.TestCase):
 
         # get all of the child types
         child_types = schema.get_child_types('unittest/person')
-        #print "CHILD TYPES ", child_types
         expected = ['unittest/person_in_car', 'unittest/house']
         my.assertEquals(True, expected[0] in child_types)
         my.assertEquals(True, expected[1] in child_types)

--- a/src/pyasm/biz/dir_naming.py
+++ b/src/pyasm/biz/dir_naming.py
@@ -142,7 +142,7 @@ class DirNaming(object):
         my._init_file_object()
 
 
-
+        
         # get the alias from the naming, if it exists
         if not alias and my.protocol in ["file", "http"]:
             if my._file_object:
@@ -374,17 +374,14 @@ class DirNaming(object):
 
 
         elif protocol == "remote":
-            # NOTE: currently needs web to do this
+            # NOTE: currently needs web to get the full http base url
             base_dir = Environment.get_env_object().get_base_url().to_string()
 
-            repo_handler = my.sobject.get_repo_handler(my.snapshot)
-            if repo_handler.is_tactic_repo():
-                sub_dir = Config.get_value("checkin", "web_base_dir")
-            else:
-                sub_dir = Config.get_value("perforce", "web_base_dir")
+       
+            sub_dir = my.get_base_dir(protocol='http', alias=alias)
+            base_dir = "%s%s" % (base_dir, sub_dir[0])
 
-            base_dir = "%s%s" % (base_dir, sub_dir)
-
+            
         elif protocol == "file":
             base_dir = Environment.get_asset_dir(alias=alias)
 

--- a/src/pyasm/biz/naming_test.py
+++ b/src/pyasm/biz/naming_test.py
@@ -587,10 +587,11 @@ class NamingTest(unittest.TestCase):
         sand_paths = virtual_snapshot.get_all_lib_paths(mode='sandbox')
         client_paths = virtual_snapshot.get_all_lib_paths(mode='client_repo')
        
-        base_dir = Config.get_value("checkin", "asset_base_dir")
+        base_dir = Config.get_value("checkin", "asset_base_dir", sub_key='default')
         sand_base_dir = dir_naming.get_base_dir(protocol='sandbox')
         client_base_dir = dir_naming.get_base_dir(protocol='client_repo')
-        
+       
+
         my.assertEquals(lib_paths[0].startswith('%s%s'%(base_dir, expected_dir_name2)), True)
         my.assertEquals(sand_paths[0].startswith('%s%s'%(sand_base_dir[0], expected_dir_name2)), True)
         my.assertEquals(client_paths[0].startswith('%s%s'%(client_base_dir[0], expected_dir_name2)), True)

--- a/src/pyasm/checkin/checkin_test.py
+++ b/src/pyasm/checkin/checkin_test.py
@@ -17,7 +17,7 @@ import os,unittest, shutil, sys
 
 from pyasm.unittest import *
 
-from pyasm.common import Environment, Config, Common, Container
+from pyasm.common import Environment, Config, Common, Container, Xml
 from pyasm.command import Command, UndoCmd
 from pyasm.search import Transaction, SearchType, Search
 from pyasm.security import Batch
@@ -48,17 +48,20 @@ class CheckinTest(unittest.TestCase, Command):
 
         test_env = UnittestEnvironment()
         test_env.create()
+        my.transaction = Transaction.get(create=True)
 
         Project.set_project("unittest")
-
+       
         try:
-            Command.execute_cmd(my)
+            #Command.execute_cmd(my)
 
             # undo the command
-            undo = UndoCmd()
-            undo.execute()
+            #undo = UndoCmd()
+            #undo.execute()
+            my.execute()
 
         finally:
+            my.transaction.rollback()
             test_env.delete()
 
 
@@ -88,6 +91,12 @@ class CheckinTest(unittest.TestCase, Command):
    
         my._test_base_dir_alias()
 
+        # clear the xml and config cache introduced by test_base_dir_alias
+        data = {}
+        Container.put(Config.CONFIG_KEY, data)
+
+        Xml.XML_FILE_CACHE = {}
+        Xml.XML_FILE_MTIME = {}
 
 
     def clear_naming(my):
@@ -793,6 +802,11 @@ class CheckinTest(unittest.TestCase, Command):
             path = "%s/text.txt" % (lib_dir)
             exists = os.path.exists(path)
             my.assertEquals(True, exists)
+
+        # manually remove this from this pseudo asset_base_dir as we
+        # clean up using the default asset_base_dir at the end
+        os.unlink('/tmp/tactic/alias/alias/text.txt')
+        os.unlink('/tmp/tactic/alias2/alias2/text.txt')
 
 
 

--- a/src/pyasm/common/config.py
+++ b/src/pyasm/common/config.py
@@ -114,6 +114,7 @@ class Config(Base):
 
 
     def get_section_values(section_name):
+        '''Get the nodes in a section of an xml as dictionary of name:value pair'''
         xml_data = Config.get_xml_data()
         xpath = "config/%s" % section_name
         node = xml_data.get_node(xpath)

--- a/src/pyasm/prod/service/api_xmlrpc.py
+++ b/src/pyasm/prod/service/api_xmlrpc.py
@@ -2561,6 +2561,17 @@ class ApiXMLRPC(BaseApiXMLRPC):
     def get_base_dirs(my, ticket):
         '''get all of the base directories defined on the server'''
         data = Config.get_section_values("checkin")
+        for key, value in data.items():
+            if value.strip().startswith('{'):
+                
+                try:
+                    sub_value = eval(value.strip())
+                    value = sub_value
+                    data[key] = value
+                except:
+                    pass
+
+       
         return data
 
 
@@ -3779,7 +3790,6 @@ class ApiXMLRPC(BaseApiXMLRPC):
         search_type = sobject.get_search_type()
         search_id = sobject.get_id()
         search_key = SearchKey.get_by_sobject(sobject)
-
         # get the level object
         if level_key:
             level = SearchKey.get_by_search_key(level_key)
@@ -3801,6 +3811,7 @@ class ApiXMLRPC(BaseApiXMLRPC):
             raise ApiException("Snapshot for [%s] with context [%s] is locked" % (search_key, context))
 
         paths = {}
+
         if file_type == "*":
             client_lib_paths = snapshot.get_all_client_lib_paths()
             paths['client_lib_paths'] = client_lib_paths

--- a/src/pyasm/search/sql.py
+++ b/src/pyasm/search/sql.py
@@ -1253,7 +1253,8 @@ class DbContainer(Base):
         if sql and sql.get_connection():
             DbContainer.register_connection(sql) 
 
-        assert sql.get_connection()
+        # delete of Unittest environment requires this to be commented out
+        #assert sql.get_connection()
         return sql
 
     get = classmethod(get)


### PR DESCRIPTION
  fixed undo files in checkin_test
  fixed remote protocol get_base_dir
  added is_revision to the handling auto checkin_type
  made api method get_base_dirs() return the data as dictionaries if a dir has multiple entries like asset_base_dir
  commented out assert of sql.get_connection in DbContainer.get()
