### PR TITLE
Bugfix in .spt file export

### DIFF
--- a/src/pyasm/search/sql_dumper.py
+++ b/src/pyasm/search/sql_dumper.py
@@ -384,7 +384,8 @@ class TableDataDumper(object):
 
 
                             # repr puts single quotes at the start and end
-                            value = value[1:-1]
+                            if value.startswith("'") and value.endswith("'"):
+                                value = value[1:-1]
                             # and it puts a slash in front
                             value = value.replace(r"\'", "'")
                             # replace literal \n with newline (comes from repr)


### PR DESCRIPTION
The original value.strip("'") call strips ALL single quotes at the start and end, not just the first and last ones inserted by repr.

This create an error when exporting a string finishing with a single quote

for example a python trigger finishing with:
return 'foo'

becomes:
return \'foo\''

after repr and:
return \'foo\

after strip

the resulting exported .spt file will have a multiline string finishing with:
return \'foo\"""

escaping one of the three double quotes and giving an error when reread by tactic.
