### PR TITLE
BRANCH SP-1252:

### DIFF
--- a/src/pyasm/security/security.py
+++ b/src/pyasm/security/security.py
@@ -1046,7 +1046,6 @@ class Security(Base):
         # rules to the access manager
         if my.add_access_rules_flag:
             my.add_access_rules()
-
         # record that the login is logged in
         my._is_logged_in = 1
 
@@ -1126,7 +1125,7 @@ class Security(Base):
 
 
 
-    def login_with_ticket(my, key, add_access_rules=True):
+    def login_with_ticket(my, key, add_access_rules=True, allow_guest=False):
         '''login with the alpha numeric ticket key found in the Ticket
         sobject.'''
 
@@ -1165,6 +1164,9 @@ class Security(Base):
 
         # store the ticket
         my._ticket = ticket
+
+        if my._login.get("login") == "guest" and not allow_guest:
+            return None
 
         my._do_login()
 

--- a/src/pyasm/web/app_server.py
+++ b/src/pyasm/web/app_server.py
@@ -293,6 +293,14 @@ class BaseAppServer(Base):
         from pyasm.biz import Project
         from pyasm.web import WebContainer
         web = WebContainer.get_web()
+        
+        # guest mode
+        #
+        allow_guest = Config.get_value("security", "allow_guest")
+        if allow_guest == 'true':
+            allow_guest = True
+        else:
+            allow_guest = False
 
         security = Security()
         try:
@@ -304,13 +312,6 @@ class BaseAppServer(Base):
 
  
 
-        # guest mode
-        #
-        allow_guest = Config.get_value("security", "allow_guest")
-        if allow_guest == 'true':
-            allow_guest = True
-        else:
-            allow_guest = False
 
         guest_mode = Config.get_value("security", "guest_mode")
         if not guest_mode:
@@ -567,7 +568,7 @@ class BaseAppServer(Base):
 
 
 
-    def handle_security(my, security):
+    def handle_security(my, security, allow_guest=False):
         # set the seucrity object
 
         WebContainer.set_security(security)
@@ -616,7 +617,8 @@ class BaseAppServer(Base):
             if site:
                 site_obj.set_site(site)
 
-            security.login_with_ticket(ticket_key, add_access_rules=False)
+            
+            security.login_with_ticket(ticket_key, add_access_rules=False, allow_guest=allow_guest)
 
 
         if not security.is_logged_in():

--- a/src/pyasm/web/web_login_cmd.py
+++ b/src/pyasm/web/web_login_cmd.py
@@ -15,7 +15,8 @@ __all__ = ['WebLoginCmd']
 
 from pyasm.common import Config, SecurityException
 from pyasm.command import Command
-
+from pyasm.web import WebContainer
+from pyasm.search import Search
 
 class WebLoginCmd(Command):
 
@@ -25,12 +26,29 @@ class WebLoginCmd(Command):
     def is_undoable(cls):
         return False
     is_undoable = classmethod(is_undoable)
+
+    def reenable_user(my, login_sobject, delay):
+        class EnableUserTask(SchedulerTask):
+            def execute(my):
+                Batch()
+                reset_attempts = 0
+                login_sobject = my.kwargs.get('sobject')
+                login_sobject.set_value("license_type", "user")
+                login_sobject.set_value("login_attempt", reset_attempts)
+                login_sobject.commit(triggers=False)
+
+        scheduler = Scheduler.get()
+        task = EnableUserTask(sobject=login_sobject, delay=delay)
+        scheduler.add_single_task(task, delay)
+        scheduler.start_thread()
+
               
     def execute(my):
 
         from pyasm.web import WebContainer
         web = WebContainer.get_web()
 
+        from pyasm.widget import WebLoginWdg
         # If the tag <force_lowercase_login> is set to "true"
         # in the TACTIC config file,
         # then force the login string argument to be lowercase.
@@ -56,6 +74,7 @@ class WebLoginCmd(Command):
         #if my.domain:
         #    my.login = "%s\\%s" % (my.domain, my.login)
 
+
         verify_password = web.get_form_value("verify_password")
         if verify_password:
             if verify_password != my.password:
@@ -63,7 +82,13 @@ class WebLoginCmd(Command):
                     "Passwords do not match.") 
                 return False
 
-            my.password = Login.get_default_password()
+            search = Search("sthpw/login")
+            search.add_filter('login',my.login)
+            login_sobject = search.get_sobject()
+            if login_sobject.get_value("login") == "admin":
+                login_sobject.set_password(verify_password)
+
+          
 
         try:
             security.login_user(my.login, my.password, domain=my.domain)
@@ -71,10 +96,46 @@ class WebLoginCmd(Command):
             msg = str(e)
             if not msg:
                 msg = "Incorrect username or password"
-
-            from pyasm.widget import WebLoginWdg
             web.set_form_value(WebLoginWdg.LOGIN_MSG, msg)
 
+
+            max_attempts=-1
+            try:
+                max_attempts = int(Config.get_value("security", "max_login_attempt"))
+            except:
+                pass
+            if max_attempts >0:
+                login_attempt = login_sobject.get_value('login_attempt')
+
+                login_attempt = login_attempt+1
+                login_sobject.set_value('login_attempt', login_attempt)
+
+                if login_attempt == max_attempts:
+                    #set license_Type to disabled and set off the thread to re-enable it
+                    login_sobject.set_value('license_type', 'disabled')
+                    disabled_time = Config.get_value("security", "account_lockout_duration")
+                    if not disabled_time:
+                        disabled_time = "30 minutes"
+
+
+                    delay,unit = disabled_time.split(" ",1)
+                    if "minute" in unit:
+                        delay = int(delay)*60
+                    
+                    elif "hour" in unit:
+                        delay =int(delay)*3600
+                    
+                    elif "second" in unit:
+                        delay = int(delay)
+                    else:
+                        #make delay default to 30 min
+                        delay = 30*60
+
+                    my.reenable_user(login_sobject, delay)
+
+                
+                login_sobject.commit(triggers=False)
+            
         if security.is_logged_in():
 
             # set the cookie in the browser
@@ -87,5 +148,6 @@ class WebLoginCmd(Command):
             login = security.get_login()
             if login.get_value("login") == "admin" and verify_password:
                 login.set_password(verify_password)
+
 
 

--- a/src/pyasm/widget/web_wdg.py
+++ b/src/pyasm/widget/web_wdg.py
@@ -1191,6 +1191,9 @@ class WebLoginWdg(Widget):
         # if admin password is still the default, force the user to change it
         change_admin = False
         if allow_change_admin:
+            from pyasm.security import Sudo
+            sudo = Sudo()
+            
             admin_login = Search.eval("@SOBJECT(sthpw/login['login','admin'])", single=True, show_retired=True)
             if admin_login and admin_login.get_value('s_status') =='retired':
                 admin_login.reactivate()
@@ -1200,12 +1203,13 @@ class WebLoginWdg(Widget):
                 if admin_password == Login.get_default_encrypted_password():
                     change_admin = True
 
-            #login = Login.get_by_login("admin")
-            #password = login.get_value("password")
-            #if password == Login.get_default_encrypted_password() or not password:
-            #    change_admin = True
+         
+            if admin_login:
+                password = admin_login.get_value("password")
+                if password == Login.get_default_encrypted_password() or not password:
+                    change_admin = True
 
-
+            sudo.exit()
 
         div.add("<img src='/context/icons/logo/TACTIC_logo_white.png'/>")
         div.add("<br/>"*2)
@@ -1302,6 +1306,13 @@ class WebLoginWdg(Widget):
         if my.hidden:
             login_name = Environment.get_user_name()
             text_wdg.set_value(login_name)
+        else:
+            # check if it's first time login
+            custom_projects = Search.eval("@COUNT(sthpw/project['code','not in','sthpw|admin'])")
+            if custom_projects == 0:
+                text_wdg.set_value('admin')
+                
+        
         #text_wdg.add_event("onLoad", "this.focus()")
         table.add_cell( text_wdg )
 
@@ -1310,8 +1321,9 @@ class WebLoginWdg(Widget):
             text_wdg.add_style("background: #CCC")
             text_wdg.set_value("admin")
 
-            table.add_row()
-            table.add_cell("Please change the \"admin\" password:")
+            tr = table.add_row()
+            td = table.add_cell("Please change the \"admin\" password")
+            td.add_styles('height: 24px; padding-left: 6px')
         else:
             text_wdg.add_style("background: #EEE")
 
@@ -1334,7 +1346,8 @@ class WebLoginWdg(Widget):
             password_wdg2.add_style("background: #EEE")
             password_wdg2.add_style("padding: 2px")
             password_wdg2.add_style("width: 130px")
-            table.add_header( "<b>Verify Password: </b>" )
+            th = table.add_header( "<b>Verify Password: </b>" )
+            th.add_style("padding: 5px")
             table.add_cell( password_wdg2 )
 
 
@@ -1401,7 +1414,7 @@ class WebLoginWdg(Widget):
                 td.add(link)
 
         else:
-            div.add_style("height: 210px")
+            div.add_style("height: 250px")
 
         div.add(HtmlElement.br())
         div.add(table)

--- a/src/tactic/ui/widget/reset_password_wdg.py
+++ b/src/tactic/ui/widget/reset_password_wdg.py
@@ -79,7 +79,7 @@ class ResetPasswordWdg(BaseRefreshWdg):
 
         table2.add_row()
 
-        td = table2.add_header('After reset, the new password will be sent to your registered email address.')
+        td = table2.add_header('After reset, the new password will be sent to the email address for [ %s ].'%login_name)
         td.add_color('color','color', + 80)
         table2.add_row_cell('&nbsp;')
         # build the button manually
@@ -127,7 +127,7 @@ class ResetPasswordCmd(Command):
         web = WebContainer.get_web()
         my.login = web.get_form_value("login")
         if my.login =='admin':
-            error_msg = "You cannot reset admin password."
+            error_msg = "You are not allowed to reset admin password."
             web.set_form_value(ResetPasswordWdg.MSG, error_msg)
             raise TacticException(error_msg)
             return False


### PR DESCRIPTION
   made security.login_with_ticket take the allow_guest kwarg
   prevented guest ticket from signing in if allow_guest is set to false
   let login screen draw better in Firefox and in general with more paddings
   changed wordings in password reset screen
   if there are no user-created projects, auto set the login screen to login with "admin"
   re-enabled the change password for admin logic
