### PR TITLE
BRANCH 4.3_timezone_str:

### DIFF
--- a/src/pyasm/search/search.py
+++ b/src/pyasm/search/search.py
@@ -3566,7 +3566,7 @@ class SObject(object):
                         value = SPTDate.add_gmt_timezone(value)
                 # stringified it if it's a datetime obj
                 if value and not isinstance(value, basestring):
-                    value = value.strftime('%Y-%m-%d %H:%M:%S %Z')
+                    value = value.strftime('%Y-%m-%d %H:%M:%S %z')
                 changed = True
 
             if changed:


### PR DESCRIPTION
  fixed a bug in Windows where the it tries to use the full time zone name to timestamp value.
  used the +numerical timezone value instead