### PR TITLE
BRANCH 4.3_plugin_publish_fix:

### DIFF
--- a/src/tactic/command/plugin.py
+++ b/src/tactic/command/plugin.py
@@ -1057,7 +1057,7 @@ class PluginInstaller(PluginBase):
         '''get unique sobject in the existing table when installing plugin'''
         base_st = sobject.get_base_search_type()
         if base_st == 'config/widget_config':
-            cols = ['view','search_type','category','widget_type']
+            cols = ['view','search_type','category','widget_type','login']
         elif base_st == 'config/naming':
             cols = ['search_type','context','checkin_type','snapshot_type','condition','latest_versionless','current_versionless','manual_version']
         elif base_st == 'config/url':

--- a/src/tactic/ui/app/plugin_wdg.py
+++ b/src/tactic/ui/app/plugin_wdg.py
@@ -730,6 +730,7 @@ class PluginEditWdg(BaseRefreshWdg):
         if my.mode == 'insert':
             tr.add_style("display: none")
         td = table.add_cell()
+        td.add_class('spt_table_header')
         td.add("Version: ")
 
         td.add_style("vertical-align: top")
@@ -809,10 +810,15 @@ class PluginEditWdg(BaseRefreshWdg):
                 spt.alert("Cannot publish DEV version. Please change the version.");
                 return;
             }
+            if (version.match(/^v/i)) {
+                spt.alert("We recommend Version not starting with a V.")
+                return;
+            }
 
 
+            // PluginCreator handles version as well
             var exec = function() {
-                var class_name = 'tactic.ui.app.PluginVersionCreator';
+                var class_name = 'tactic.command.PluginCreator';
                 var kwargs = {
                     code: code,
                     version: version,
@@ -1173,8 +1179,10 @@ class PluginEditWdg(BaseRefreshWdg):
             }
 
 
+            // PluginCreator handles version as well
             var exec = function() {
-                var class_name = 'tactic.ui.app.PluginVersionCreator';
+                var class_name = 'tactic.command.PluginCreator';
+
                 var kwargs = {
                     code: code,
                     version: version,
@@ -1588,7 +1596,10 @@ class PluginEditWdg(BaseRefreshWdg):
                 spt.alert("Cannot create DEV version");
                 return;
             }
-
+            if (version.match(/^v/i)) {
+                spt.alert("We recommend Version not starting with a V.")
+                return;
+            }
 
             var class_name = 'tactic.ui.app.PluginVersionCreator';
             var kwargs = {
@@ -1604,7 +1615,7 @@ class PluginEditWdg(BaseRefreshWdg):
             var top = bvr.src_el.getParent(".spt_plugin_top");
             spt.panel.refresh(top);
 
-            spt.notify.show_message('Plugin [' + code + '] v' + version+ ' created.');
+            spt.notify.show_message('Plugin [' + code + '] ' + version+ ' created.');
             
             '''
             } )


### PR DESCRIPTION
  made the Publish Plugin button use PluginCreator instead of the outdated PluginVersionCreator
  made some slight position adjustment to the Manage Plugin widget
  warned the user from beginning a version with the V in the version field