### PR TITLE
BRANCH 4.3_expr_search_fix:

### DIFF
--- a/src/tactic/ui/filter/filter_wdg.py
+++ b/src/tactic/ui/filter/filter_wdg.py
@@ -1784,6 +1784,8 @@ class GeneralFilterWdg(BaseFilterWdg):
                     # check here rather than letting add_relationship_filters nullifying the whole search
                     if results:
                         search.add_relationship_filters(results, op=op)
+                    elif op == 'in':
+                        search.set_null_filter()
                 else:
                     if op == 'do not match':
                         op = 'not in'


### PR DESCRIPTION
   set null filter on the expression search if the user chooses Expression "have" and provide an expression that doesn't return any results