### PR TITLE
VFX: Update the Group creation UI in Users and Security Page: as a manag...

### DIFF
--- a/src/tactic/ui/startup/security_wdg.py
+++ b/src/tactic/ui/startup/security_wdg.py
@@ -229,12 +229,29 @@ class GroupAssignWdg(BaseRefreshWdg):
             'cbjs_action': '''
             var top = bvr.src_el.getParent(".spt_groups_top");
             var add = top.getElement(".spt_groups_add");
+            var checkbox = top.getElement(".spt_include_project_checkbox");
+            var checkbox_label = top.getElement(".spt_include_project_checkbox_label");
             spt.toggle_show_hide(add);
+            spt.toggle_show_hide(checkbox);
+            spt.toggle_show_hide(checkbox_label);
             '''
         } )
 
+        checkbox = CheckboxWdg("Include Project Name")
+        checkbox.set_option("value", "true")
+        checkbox.add_class("spt_include_project_checkbox")
+        checkbox.add_style("display: none")
+        checkbox.add_style("margin-left: 30px")
+        checkbox.set_checked()
+        checkbox_label = SpanWdg(" Project specific")
+        checkbox_label.add_style("display: none")
+        checkbox_label.add_class("spt_include_project_checkbox_label")
+        checkbox.add(checkbox_label)
+        top.add(checkbox)
 
-        action_button = ActionButtonWdg(title="Save >>")
+
+        action_button = ActionButtonWdg(title="Save")
+        action_button.add_style("margin-right: 10px")
         top.add(action_button)
         action_button.add_style("float: right")
         action_button.add_behavior( {
@@ -246,9 +263,13 @@ class GroupAssignWdg(BaseRefreshWdg):
 
             var top = bvr.src_el.getParent(".spt_groups_top");
 
+            var checkbox = top.getElement(".spt_include_project_checkbox");
+            var checked = checkbox.checked;
+
             var values = spt.api.Utility.get_input_values(top);
             var kwargs = {
-                values: values
+                values: values,
+                "checked": checked
             }
 
             var cmd = 'tactic.ui.startup.GroupAssignCbk';
@@ -335,7 +356,7 @@ class GroupAssignWdg(BaseRefreshWdg):
 
         title = DivWdg()
         div.add(title)
-        title.add("Add New Groups: ")
+        title.add(" Add New Groups: ")
         title.add_color("background", "background3")
         title.add_style("padding: 8px")
         title.add_style("margin: -5px -5px 10px -5px")
@@ -422,8 +443,13 @@ class GroupAssignCbk(Command):
             new_group = Common.get_filesystem_name(new_group)
 
             group = SearchType.create("sthpw/login_group")
-            group.set_value("login_group", new_group)
-            group.set_value("project_code", project_code)
+            
+            if my.kwargs.get("checked") in [True, "true", "True"]:
+                group.set_value("project_code", project_code)
+                group.set_value("login_group", new_group)
+            else:
+                group.set_value("login_group", title)
+
             group.set_value("description", title)
             group.commit()
 

--- a/src/tactic/ui/startup/security_wdg.py
+++ b/src/tactic/ui/startup/security_wdg.py
@@ -459,7 +459,9 @@ class GroupAssignCbk(Command):
             if not is_project_specific and project_included:
                 
                 # Raise exception because it's contradictory data
-                raise TacticException('''You've given a project code while declaring the group not project specific. You can either not use the format "project_code/group_name", or check the "Project specific" checkbox.''')
+                raise TacticException('''You've given a project code while declaring 
+                    the group not project specific. You can either not use the format 
+                    "project_code/group_name", or check the "Project specific" checkbox.''')
 
             # if the input is (project/name) and (project specific)
             elif is_project_specific and project_included:
@@ -467,13 +469,14 @@ class GroupAssignCbk(Command):
                 # first check is the user_defined_project_code is actually a project
                 # if it is, then set that as the project code. If not, don't set anything
 
-                expr = "@SOBJECT(sthpw/project['code', '%s'])" % user_defined_project_code
-                existing_project_codes = Search.eval(expr)
+                user_defined_project = Project.get_by_code(user_defined_project_code)
 
-                if existing_project_codes:
+                if user_defined_project:
                     group.set_value("project_code", user_defined_project_code)
                 else:
-                    raise TacticException('''The project code that you've given doesn't exist. Please choose an existing project code. Note: the format is "project_code/group_name". Projects include: %s''' % ", ".join(existing_project_codes))
+                    raise TacticException('''The project code that you've given doesn't exist.
+                        Please choose an existing project code. Note: the format is
+                        "project_code/group_name".''')
                 group.set_value("login_group", original_new_group)
 
             # if the input is (name) and (not project specific)

--- a/src/tactic/ui/startup/security_wdg.py
+++ b/src/tactic/ui/startup/security_wdg.py
@@ -32,8 +32,6 @@ from tactic.ui.widget import ActionButtonWdg, IconButtonWdg
 
 from tactic.ui.panel import SideBarBookmarkMenuWdg
 
-from tactic_client_lib import TacticServerStub
-
 class UserAssignWdg(BaseRefreshWdg):
 
 
@@ -269,7 +267,7 @@ class GroupAssignWdg(BaseRefreshWdg):
 
             var values = spt.api.Utility.get_input_values(top);
             var kwargs = {
-                values: values,
+                "values": values,
                 "checked": checked
             }
 
@@ -457,33 +455,32 @@ class GroupAssignCbk(Command):
             # the following sections contains the 4 cases possible when creating a new group
             # through the popup
             
-            # if the user has (project/name) and (not project specific)
+            # if the input is (project/name) and (not project specific)
             if not is_project_specific and project_included:
                 
                 # Raise exception because it's contradictory data
-                raise TacticException('''You've given a project name while declaring the group not project specific. You can either not use the format "project_code/group_name", or check the "Project specific" checkbox.''')
+                raise TacticException('''You've given a project code while declaring the group not project specific. You can either not use the format "project_code/group_name", or check the "Project specific" checkbox.''')
 
-            # if the user has (project/name) and (project specific)
+            # if the input is (project/name) and (project specific)
             elif is_project_specific and project_included:
 
                 # first check is the user_defined_project_code is actually a project
                 # if it is, then set that as the project code. If not, don't set anything
 
-                expr = "@GET(sthpw/project.code)"
-                server = TacticServerStub.get()
-                existing_project_codes = server.eval(expr)
+                expr = "@SOBJECT(sthpw/project['code', '%s'])" % user_defined_project_code
+                existing_project_codes = Search.eval(expr)
 
-                if user_defined_project_code in existing_project_codes:
+                if existing_project_codes:
                     group.set_value("project_code", user_defined_project_code)
                 else:
                     raise TacticException('''The project code that you've given doesn't exist. Please choose an existing project code. Note: the format is "project_code/group_name". Projects include: %s''' % ", ".join(existing_project_codes))
                 group.set_value("login_group", original_new_group)
 
-            # if the user has (name) and (not project specific)
+            # if the input is (name) and (not project specific)
             elif not is_project_specific and not project_included:
                 group.set_value("login_group", title)
 
-            # if the user has (name) and (project specific)
+            # if the input is (name) and (project specific)
             else:
                 group.set_value("project_code", project_code)
                 group.set_value("login_group", new_group)


### PR DESCRIPTION
...er, I should have a choice of create a group name without the project code prepended to it. Add a checkbox option for instance.. The default now is to prepend it. so I need to create a group called vfx_lead as is.