### PR TITLE
BRANCH SP-1532:

### DIFF
--- a/src/context/spt_js/panel.js
+++ b/src/context/spt_js/panel.js
@@ -228,6 +228,8 @@ spt.panel.load_popup = function(popup_id, class_name, args, kwargs) {
         bvr2.options.width = kwargs.width;
     if (kwargs.height) 
         bvr2.options.height = kwargs.height;
+    if (kwargs.allow_close != null) 
+        bvr2.options.allow_close = kwargs.allow_close;
 
     return spt.popup.get_widget({}, bvr2);
 

--- a/src/tactic/ui/container/popup_wdg.py
+++ b/src/tactic/ui/container/popup_wdg.py
@@ -284,7 +284,7 @@ class PopupWdg(BaseRefreshWdg):
 
         # create the 'close' button ...
         if my.allow_close:
-            close_wdg = SpanWdg()
+            close_wdg = SpanWdg(css='spt_popup_close')
             #close_wdg.add( IconWdg("Close", IconWdg.POPUP_WIN_CLOSE) )
             close_wdg.add( IconWdg("Close", "BS_REMOVE") )
             close_wdg.add_style("margin: 5px 1px 3px 1px")
@@ -300,7 +300,7 @@ class PopupWdg(BaseRefreshWdg):
 
 
             # create the 'minimize' button ...
-            minimize_wdg = SpanWdg()
+            minimize_wdg = SpanWdg(css='spt_popup_min')
             minimize_wdg.add_style("margin: 5px 1px 3px 1px")
             #minimize_wdg.add( IconWdg("Minimize", IconWdg.POPUP_WIN_MINIMIZE) )
             minimize_wdg.add( IconWdg("Minimize", "BS_MINUS") )
@@ -899,6 +899,7 @@ spt.popup.get_widget = function( evt, bvr )
     // get the title
     var width = options["width"];
     var height = options["height"];
+    var allow_close = options["allow_close"];
 
     // If bvr has 'popup_id' then check if it already exists and use it (instead of cloning)
     var popup = null;
@@ -921,6 +922,8 @@ spt.popup.get_widget = function( evt, bvr )
         // var popup = spt.behavior.clone(popup_template);  // PREVIOUS (doesn't work well in IE)
         var popup = spt.behavior.duplicate_element(popup_template);
 
+
+
         if( popup_id ) {
             popup.set("id", popup_id);
         } else {
@@ -942,6 +945,16 @@ spt.popup.get_widget = function( evt, bvr )
         spt.puw.process_new( popup.parentNode );
     }
 
+    var close_wdg = popup.getElement('.spt_popup_close');
+    var min_wdg = popup.getElement('.spt_popup_min');
+    if ([false, 'false'].contains(allow_close)) {
+        spt.hide(close_wdg);
+        spt.hide(min_wdg);
+    }
+    else {
+        spt.show(close_wdg);
+        spt.show(min_wdg);
+    }
     // display the popup clone, and bring it forward on top of other popups ...
     // but put it off screen first
     popup.setStyle("left", "-10000px")


### PR DESCRIPTION
   fixed the allow_close kwarg not being recognized when called from spt.panel.load_popup()..
e.g. spt.panel.load_popup('task table', 'tactic.ui.panel.ViewPanelWdg',
{'search_type': 'sthpw/task', 'view': 'table'},  {'allow_close': false});