### PR TITLE
Sp 1554

### DIFF
--- a/src/context/spt_js/utility.js
+++ b/src/context/spt_js/utility.js
@@ -1409,9 +1409,12 @@ spt.error = function(msg, options){
 
 }
 
-/* var ok = function(ok_arg) {alert('passed in an arg ' + ok_arg)};
-   var cancel = null;
-   spt.confirm("Continue? ", ok, cancel, {ok_args: 'first', cancel_args: 'nothing'});
+/* Control flow for MooDialog confirm. On OK, calls OK function with argument
+ * ok_args  and on cancel, calls cancel function with cancel_args.
+ * Example usage: 
+ * var ok = function(ok_arg_list) {alert('passed in multiple arguments: ' + ok_arg_list)};
+ * var cancel = function(cancel_arg) {alert('passed in one argument: ' + cancel_arg')}
+   spt.confirm("Continue? ", ok, cancel, {ok_args: ["one","two","three"], cancel_args: 'nothing'});
  */
 spt.confirm = function(msg, button_fn1, button_fn2, options){
   

--- a/src/tactic/ui/container/tab_wdg.py
+++ b/src/tactic/ui/container/tab_wdg.py
@@ -846,12 +846,16 @@ spt.tab.close = function(src_el) {
         return;
     }
     
-    var changed_element = false;
-    var changed_type = false;
-    function ok() {
+    /* If there are changed elements in the current tab, changedParameters
+     * is a list with index 0 containing changed element, and index 1 containing
+     * change type class. Otherwise, changedParameters is false. 
+     */
+    function ok(changedParameters) {
         //Remove unsaved changes flags
-        if (changed_element) {
-             changed_element.removeClass(changed_type);
+        if (changedParameters) {
+            var changed_element = changedParameters[0];
+            var changed_type = changedParameters[1];
+            changed_element.removeClass(changed_type);
         }
 
         var opener = header.getAttribute("spt_tab_opener");
@@ -880,17 +884,13 @@ spt.tab.close = function(src_el) {
     var changed_row = content.getElement(".spt_row_changed");
     
     if (changed_el) {
-        changed_element = changed_el;
-        changed_type = "spt_has_changed";
-        spt.confirm("There are unsaved changes in the current tab. Continue without saving?", ok, null);
+        spt.confirm("There are unsaved changes in the current tab. Continue without saving?", ok, null, {ok_args : [changed_el, "spt_has_changed"]});
     }
     else if (changed_row) {
-        changed_element = changed_row;
-        changed_type = "spt_row_changed";
-        spt.confirm("There are unsaved changes in the current tab. Continue without saving?", ok, null);
+        spt.confirm("There are unsaved changes in the current tab. Continue without saving?", ok, null, {ok_args: [changed_row, "spt_row_changed"]});
     }
     else {
-       ok();
+       ok(false);
     }
 }
 

--- a/src/tactic/ui/container/tab_wdg.py
+++ b/src/tactic/ui/container/tab_wdg.py
@@ -815,6 +815,7 @@ spt.tab.header_drag_action = function( evt, bvr, mouse_411) {
 }
 
 spt.tab.close = function(src_el) {
+
     // src_el should be a child of spt_tab_content or spt_tab_header
     if (!src_el) {
         spt.error('src_el passed in to spt.tab.close() does not exist.');
@@ -844,27 +845,52 @@ spt.tab.close = function(src_el) {
         spt.error('Tab close cannot find the header or content. Abort');
         return;
     }
-
     
-    var opener = header.getAttribute("spt_tab_opener");
-    var element_name = header.getAttribute("spt_element_name");
-    header.destroy();
+    var changed_element = false;
+    var changed_type = false;
+    function ok() {
+        //Remove unsaved changes flags
+        if (changed_element) {
+             changed_element.removeClass(changed_type);
+        }
 
-    content.destroy();
+        var opener = header.getAttribute("spt_tab_opener");
+        var element_name = header.getAttribute("spt_element_name");
+        header.destroy();
 
-    var last_element_name = spt.tab.get_last_selected_element_name();
-    last_element_name = null;
+        content.destroy();
 
-    // make the opener active
-    if (opener) {
-        spt.tab.select(opener);
+        var last_element_name = spt.tab.get_last_selected_element_name();
+        last_element_name = null;
+
+        // make the opener active
+        if (opener) {
+             spt.tab.select(opener);
+        }
+        else if (last_element_name) {
+            spt.tab.select(last_element_name);
+        }
+        else {
+            var last = headers[headers.length - 1].getAttribute("spt_element_name");
+            spt.tab.select(last);
+        }
     }
-    else if (last_element_name) {
-        spt.tab.select(last_element_name);
+   
+    var changed_el = content.getElement(".spt_has_changes");
+    var changed_row = content.getElement(".spt_row_changed");
+    
+    if (changed_el) {
+        changed_element = changed_el;
+        changed_type = "spt_has_changed";
+        spt.confirm("There are unsaved changes in the current tab. Continue without saving?", ok, null);
+    }
+    else if (changed_row) {
+        changed_element = changed_row;
+        changed_type = "stp_row_changed";
+        spt.confirm("There are unsaved changes in the current tab. Continue without saving?", ok, null);
     }
     else {
-        var last = headers[headers.length - 1].getAttribute("spt_element_name");
-        spt.tab.select(last);
+       ok();
     }
 }
 

--- a/src/tactic/ui/container/tab_wdg.py
+++ b/src/tactic/ui/container/tab_wdg.py
@@ -886,7 +886,7 @@ spt.tab.close = function(src_el) {
     }
     else if (changed_row) {
         changed_element = changed_row;
-        changed_type = "stp_row_changed";
+        changed_type = "spt_row_changed";
         spt.confirm("There are unsaved changes in the current tab. Continue without saving?", ok, null);
     }
     else {

--- a/src/tactic/ui/tools/pipeline_canvas_wdg.py
+++ b/src/tactic/ui/tools/pipeline_canvas_wdg.py
@@ -211,8 +211,14 @@ class PipelineCanvasWdg(BaseRefreshWdg):
         } )
 
 
-
-
+        canvas.add_behavior( {
+        "type": 'click_up',
+        "cbjs_action": '''
+        // Add edited flag
+        var editor_top = bvr.src_el.getParent(".spt_pipeline_editor_top");
+        editor_top.addClass("spt_has_changes");
+        '''
+        })
 
         # create the paint where all the connectors are drawn
         paint = my.get_paint()

--- a/src/tactic/ui/tools/pipeline_wdg.py
+++ b/src/tactic/ui/tools/pipeline_wdg.py
@@ -675,7 +675,7 @@ class PipelineListWdg(BaseRefreshWdg):
             for ( var i = 0; i < select.options.length; i++) {
                 var select_value = select.options[i].value;
                 if (select_value == value) {
-                    alert("Pipeline ["+value+"] already exists");
+                    spt.alert("Pipeline ["+value+"] already exists");
                     return;
                 }
             }  
@@ -737,7 +737,7 @@ class PipelineListWdg(BaseRefreshWdg):
         menu_item = MenuItem(type='action', label='Copy to Project')
         menu_item.add_behavior( {
             'cbjs_action': '''
-            alert('Not implemented');
+            spt.alert('Not implemented');
             '''
         } )
         menu.add(menu_item)
@@ -1580,7 +1580,7 @@ class PipelineEditorWdg(BaseRefreshWdg):
             var editor_top = bvr.src_el.getParent(".spt_pipeline_editor_top");
             var ok = function () { 
                 editor_top.removeClass("spt_has_changes");
-                spt.panel.refresh(editor_top);
+                spt.panel.refresh(editor_top); 
             }
 
             if (editor_top && editor_top.hasClass("spt_has_changes")) {
@@ -2127,7 +2127,7 @@ class PipelineEditorWdg(BaseRefreshWdg):
         var values = spt.api.get_input_values(dialog_top, null, false);
         var value = values.new_pipeline;
         if (value == '') {
-            alert("Cannot add empty pipeline");
+            spt.alert("Cannot add empty pipeline");
             return;
         }
 
@@ -2137,7 +2137,7 @@ class PipelineEditorWdg(BaseRefreshWdg):
         for ( var i = 0; i < select.options.length; i++) {
             var select_value = select.options[i].value;
             if (select_value == value) {
-                alert("Pipeline ["+value+"] already exists");
+                spt.alert("Pipeline ["+value+"] already exists");
                 return;
             }
         }
@@ -2756,7 +2756,7 @@ spt.pipeline_properties.set_properties = function() {
     var selected_nodes = spt.pipeline.get_selected_nodes();
     var selected = spt.pipeline.get_selected();
     if (selected_nodes.length > 1) {
-        alert('Please select only 1 node to set property');
+        spt.alert('Please select only 1 node to set property');
         return;
     }
         

--- a/src/tactic/ui/tools/pipeline_wdg.py
+++ b/src/tactic/ui/tools/pipeline_wdg.py
@@ -1401,11 +1401,6 @@ class PipelineEditorWdg(BaseRefreshWdg):
         canvas_top.add_style("position: relative")
         canvas = my.get_canvas()
         canvas_top.add(canvas)
-        canvas_top.add_behavior( {
-            'type': 'click',
-            'cbjs_action': '''
-            '''
-        })
 
         canvas_title = DivWdg()
         canvas_top.add(canvas_title)


### PR DESCRIPTION
Pipeline editor tab now detects changes in the pipeline canvas. This includes the pipeline editor menu items (refresh, save, add process etc.), sidebar navigator (to open other pipelines to view) and the close button.

Included is the detecting of changed rows in views which contained tables when opened in tabs.