### PR TITLE
server.add_file multiple file copy/move problem

### DIFF
--- a/src/client/tactic_client_lib/tactic_server_stub.py
+++ b/src/client/tactic_client_lib/tactic_server_stub.py
@@ -2365,12 +2365,11 @@ class TacticServerStub(object):
                     elif mode == 'copy':
                         shutil.copy(file_path, "%s/%s"
                                     % (handoff_dir, basename))
-                    mode = 'create'
 
-        return my.server.add_file(my.ticket, snapshot_code, file_paths,
-                                  file_types, use_handoff_dir, mode,
-                                  create_icon, dir_naming, file_naming,
-                                  checkin_type)
+            if mode in ['copy', 'move']:
+                mode = 'create'
+
+        return my.server.add_file(my.ticket, snapshot_code, file_paths, file_types, use_handoff_dir, mode, create_icon, dir_naming, file_naming, checkin_type)
 
 
     def remove_file(my, snapshot_code, file_type):

--- a/src/client/tactic_client_lib/tactic_server_stub.py
+++ b/src/client/tactic_client_lib/tactic_server_stub.py
@@ -2369,7 +2369,10 @@ class TacticServerStub(object):
             if mode in ['copy', 'move']:
                 mode = 'create'
 
-        return my.server.add_file(my.ticket, snapshot_code, file_paths, file_types, use_handoff_dir, mode, create_icon, dir_naming, file_naming, checkin_type)
+        return my.server.add_file(my.ticket, snapshot_code, file_paths,
+                                  file_types, use_handoff_dir, mode,
+                                  create_icon, dir_naming, file_naming,
+                                  checkin_type)
 
 
     def remove_file(my, snapshot_code, file_type):


### PR DESCRIPTION
I discovered this problem when i recently upgraded from 4.1.0v05 to 4.3.0v02. Calls like these from the python api were causing problem:

```python
server.addfile(snapshot_code, ['~/a.jpg', '~/b.jpg'], file_type=['image',]*2, mode='copy') 
```
i.e. files copied (or moved) in a list

Tactic API raises an exception saying that Mode should be within ```['upload', 'copy', 'move', 'preallocate','inplace']```

keeping ```mode='create'``` in the loop is the problem