### PR TITLE
BRANCH SP-2290-1:

### DIFF
--- a/src/tactic/ui/panel/manage_view_panel_wdg.py
+++ b/src/tactic/ui/panel/manage_view_panel_wdg.py
@@ -550,7 +550,7 @@ class ManageSideBarBookmarkMenuWdg(SideBarBookmarkMenuWdg):
                 "cb_set_prefix": 'spt.side_bar.pp'
             }
             if recurse:
-                behavior['cbjs_action_onnomotion'] = ''''
+                behavior['cbjs_action_onnomotion'] = '''
                     spt.side_bar.toggle_section_display_cbk(evt,bvr);
                     spt.side_bar.display_element_info_cbk(evt,bvr);
                 '''


### PR DESCRIPTION
  removed the extra ' in the Manage Side Bar js to toggle folder display to prevent a js error