### PR TITLE
URL ENCODE BRANCH 4.4:

### DIFF
--- a/src/pyasm/widget/file_wdg.py
+++ b/src/pyasm/widget/file_wdg.py
@@ -14,6 +14,7 @@
 __all__ = ["ThumbWdg", "ThumbCmd", "FileInfoWdg"]
 
 import re, time, types, string, os
+import urllib
 
 from pyasm.common import Xml, Container, Environment, Config
 from pyasm.search import Search, SearchException, SearchKey, SqlException, DbContainer
@@ -785,8 +786,13 @@ class ThumbWdg(BaseTableElementWdg):
         else:
             file_objects = my.file_objects
 
+        protocol = my.get_option("protocol")
+        if not protocol:
+            from pyasm.prod.biz import ProdSetting
+            protocol = ProdSetting.get_value_by_key('thumbnail_protocol')
+
         # go through the nodes and try to find appropriate paths
-        my.info = ThumbWdg.get_file_info(xml, file_objects, sobject, snapshot, my.show_versionless) 
+        my.info = ThumbWdg.get_file_info(xml, file_objects, sobject, snapshot, my.show_versionless, protocol=protocol) 
         # find the link that will be used when clicking on the icon
         link_path = ThumbWdg.get_link_path(my.info, image_link_order=my.image_link_order)
 
@@ -804,9 +810,9 @@ class ThumbWdg(BaseTableElementWdg):
                 
             for file_object in snapshot_file_objects:
                 file_objects[file_object.get_code()] = file_object
-            my.info = ThumbWdg.get_file_info(xml, file_objects, sobject, snapshot, my.show_versionless) 
+            my.info = ThumbWdg.get_file_info(xml, file_objects, sobject, snapshot, my.show_versionless, protocol=protocol) 
             link_path = ThumbWdg.get_link_path(my.info, image_link_order=my.image_link_order)
-          
+            
         # define a div
         div = my.top
         div.add_class("spt_thumb_top")
@@ -929,10 +935,6 @@ class ThumbWdg(BaseTableElementWdg):
 
 
         detail = my.get_option("detail")
-        protocol = my.get_option("protocol")
-        if not protocol:
-            from pyasm.prod.biz import ProdSetting
-            protocol = ProdSetting.get_value_by_key('thumbnail_protocol')
 
         #deals with the icon attributes
         if detail == "false":
@@ -1151,7 +1153,7 @@ class ThumbWdg(BaseTableElementWdg):
         icon_link = None
         if my.info.has_key(icon_type):
             icon_link = my.info[icon_type]
-
+            print "************ ICON LINK: ", icon_link
             if not os.path.exists(repo_path):
                 icon_link = ThumbWdg.get_no_image()
                 icon_info['icon_missing'] = True
@@ -1171,7 +1173,7 @@ class ThumbWdg(BaseTableElementWdg):
         else:
             icon_link = ThumbWdg.find_icon_link(image_link, repo_path)
             #icon_size = int( 60.0 / 120.0 * float(icon_size) )
-
+            print "************ ICON LINK2: ", icon_link
         icon_info['icon_size'] = icon_size
         icon_info['icon_link'] = icon_link
 
@@ -1265,7 +1267,7 @@ class ThumbWdg(BaseTableElementWdg):
 
 
 
-    def get_file_info(xml, file_objects, sobject, snapshot, show_versionless=False, is_list=False):
+    def get_file_info(xml, file_objects, sobject, snapshot, show_versionless=False, is_list=False, protocol='http'):
         info = {}
         #TODO: {'file_type': [file_type]: [path], 'base_type': [base_type]: [file|directory|sequence]}
 
@@ -1303,6 +1305,9 @@ class ThumbWdg(BaseTableElementWdg):
                 if file_names:
                     file_name = file_names[0]
             path = "%s/%s" % (web_dir, file_name)
+
+            if protocol != "file":
+                path = urllib.pathname2url(path)
 
             if isinstance(info, dict):
                 info[type] = path

--- a/src/pyasm/widget/file_wdg.py
+++ b/src/pyasm/widget/file_wdg.py
@@ -1153,7 +1153,6 @@ class ThumbWdg(BaseTableElementWdg):
         icon_link = None
         if my.info.has_key(icon_type):
             icon_link = my.info[icon_type]
-            print "************ ICON LINK: ", icon_link
             if not os.path.exists(repo_path):
                 icon_link = ThumbWdg.get_no_image()
                 icon_info['icon_missing'] = True
@@ -1173,7 +1172,6 @@ class ThumbWdg(BaseTableElementWdg):
         else:
             icon_link = ThumbWdg.find_icon_link(image_link, repo_path)
             #icon_size = int( 60.0 / 120.0 * float(icon_size) )
-            print "************ ICON LINK2: ", icon_link
         icon_info['icon_size'] = icon_size
         icon_info['icon_link'] = icon_link
 

--- a/src/tactic/ui/checkin/snapshot_files_wdg.py
+++ b/src/tactic/ui/checkin/snapshot_files_wdg.py
@@ -177,6 +177,12 @@ class SnapshotDirListWdg(DirListWdg):
             var url = "/assets/" + path.replace(asset_dir, "");
             //window.open(url);
 
+            var url_parts = url.split("/");
+            var file = url_parts.pop();
+            file = encodeURIComponent(file);
+            url_parts.push(file);
+            url = url_parts.join("/");
+
             var class_name = 'tactic.ui.widget.EmbedWdg';
             var kwargs = {
                 src: url
@@ -201,6 +207,13 @@ class SnapshotDirListWdg(DirListWdg):
             else {
             var asset_dir = '%s';
             var url = "/assets/" + path.replace(asset_dir, "");
+
+            var url_parts = url.split("/");
+            var filename = url_parts.pop();
+            filename = encodeURIComponent(filename);
+            url_parts.push(filename);
+            url = url_parts.join("/");
+
             window.open(url);
             }
             ''' % asset_dir

--- a/src/tactic/ui/panel/tile_layout_wdg.py
+++ b/src/tactic/ui/panel/tile_layout_wdg.py
@@ -12,6 +12,7 @@
 __all__ = ["TileLayoutWdg"]
 
 import re, os
+import urllib
 
 from pyasm.biz import CustomScript, Project
 from pyasm.common import Common
@@ -652,12 +653,24 @@ class TileLayoutWdg(ToolLayoutWdg):
                 else {
                     var snapshot = server.get_snapshot(search_key, {context: "", process: bvr.process, include_web_paths_dict:true});
                     if (snapshot.__search_key__) {
-                        window.open(snapshot.__web_paths_dict__.main);
+                        var snapshot_path = snapshot.__web_paths_dict__.main;
+                        var path_list = snapshot_path[0].split("/");
+                        var filename = path_list.pop();
+                        filename = encodeURIComponent(filename);
+                        path_list.push(filename);
+                        snapshot_path = path_list.join("/");
+                        window.open(snapshot_path);
                     }
                     else {
                         var snapshot = server.get_snapshot(search_key, {context: "", include_web_paths_dict:true});
                         if (snapshot.__search_key__) {
-                            window.open(snapshot.__web_paths_dict__.main);
+                            var snapshot_path = snapshot.__web_paths_dict__.main;
+                            var path_list = snapshot_path[0].split("/");
+                            var filename = path_list.pop();
+                            filename = encodeURIComponent(filename);
+                            path_list.push(filename);
+                            snapshot_path = path_list.join("/");
+                            window.open(snapshot_path);
                         }
                         else {
                             alert("WARNING: No file for this asset");
@@ -1950,14 +1963,16 @@ class ThumbWdg2(BaseRefreshWdg):
                 div.set_attr("spt_image_size", image_size)
 
 
-
         if path:
+	    path = urllib.pathname2url(path)
             img = HtmlElement.img(src=path)
         else:
             search_type = sobject.get_search_type_obj()
             path = my.get_path_from_sobject(search_type)
 
             if path:
+                path = urllib.pathname2url(path)
+
                 img = DivWdg()
                 img.add_style("opacity: 0.2")
 

--- a/src/tactic/ui/panel/tile_layout_wdg.py
+++ b/src/tactic/ui/panel/tile_layout_wdg.py
@@ -1964,7 +1964,7 @@ class ThumbWdg2(BaseRefreshWdg):
 
 
         if path:
-	    path = urllib.pathname2url(path)
+            path = urllib.pathname2url(path)
             img = HtmlElement.img(src=path)
         else:
             search_type = sobject.get_search_type_obj()

--- a/src/tactic/ui/widget/gallery_wdg.py
+++ b/src/tactic/ui/widget/gallery_wdg.py
@@ -13,6 +13,8 @@
 
 __all__ = ['GalleryWdg']
 
+import urllib
+
 from pyasm.biz import Snapshot, File
 from pyasm.search import Search
 from pyasm.web import HtmlElement, DivWdg, Table
@@ -559,6 +561,10 @@ class GalleryWdg(BaseRefreshWdg):
                 '/assets/test/store/Another%20one_v001.jpg',
                 '/assets/test/store/Whatever_v001.jpg'
             ]
+
+        for index,path in enumerate(paths):
+            path = urllib.pathname2url(path)
+            paths[index] = path
 
         return paths
 


### PR DESCRIPTION
- Modified the ThumbWdg, ThumbWdg2, SnapshotDirListWdg, TileLayoutWdg and GalleryWdg to encode URL paths to display files correctly in the browser when clicking on files to view