### PR TITLE
Bug fix in guest user creation

### DIFF
--- a/src/pyasm/security/security.py
+++ b/src/pyasm/security/security.py
@@ -1233,6 +1233,7 @@ class Security(Base):
             my._login = SearchType.create("sthpw/login")
             my._login.set_value("code", login_name)
             my._login.set_value("login", login_name)
+            my._login.set_value("upn", login_name)
             my._login.set_value("first_name", "Guest")
             my._login.set_value("last_name", "User")
             my._login.set_value("display_name", "Guest")


### PR DESCRIPTION
Fixed a bug with the creation of the guest user where the NOT NULL column 'apn' was not set resulting in not being able to login on e freshly installed tactic