### PR TITLE
Fixed two bugs related to the 'upn' column in 'login' table

### DIFF
--- a/src/install/install.py
+++ b/src/install/install.py
@@ -323,8 +323,8 @@ INSERT INTO login_group (login_group, description)
 VALUES ('admin', 'Site Administration');
 
         --add in admin user, default password 'tactic'
-INSERT INTO "login" ("login", "password", first_name, last_name)
-VALUES ('admin', '39195b0707436a7ecb92565bf3411ab1', 'Admin', '');
+INSERT INTO "login" ("login", "password", "upn", first_name, last_name)
+VALUES ('admin', '39195b0707436a7ecb92565bf3411ab1', 'admin', 'Admin', '');
 
         --add the admin user to the admin group
 INSERT INTO login_in_group ("login", login_group) VALUES ('admin', 'admin');

--- a/src/pyasm/security/security.py
+++ b/src/pyasm/security/security.py
@@ -1245,6 +1245,7 @@ class Security(Base):
             my._login = SearchType.create("sthpw/login")
             my._login.set_value("code", login_name)
             my._login.set_value("login", login_name)
+            my._login.set_value("upn", login_name)
             my._login.set_value("first_name", "Guest")
             my._login.set_value("last_name", "User")
             my._login.set_value("display_name", "Guest")


### PR DESCRIPTION
This is just a new pull request against branch 4.5 for two commits already merged in master

Fixed two bugs:
- the installation script tried to add the admin user without setting the NOT NULL column 'upn' 
- the creation of the guest user where the NOT NULL column 'upn' was not set resulted in not being able to login on e freshly installed tactic
