### PR TITLE
Strip version variable in install.py before using it as a name for installation directory

### DIFF
--- a/src/install/install.py
+++ b/src/install/install.py
@@ -409,7 +409,7 @@ VALUES ('shot_attr_change', 'Attribute Changes For Shots', 'email', 'prod/shot',
         f = open('%s/VERSION' %current_dir,'r')
         version = f.readline()
         f.close()
-        return version
+        return version.strip()
 
     def in_directory(my, file, directory):
         #make both absolute    


### PR DESCRIPTION
The VERSION file as a line feed at the end resulting in the installation dir name finishing with a \lf, I added a .strip() to sanitize any ending or starting blank character