### PR TITLE
WORK-354:

### DIFF
--- a/src/tactic/command/global_search_trigger.py
+++ b/src/tactic/command/global_search_trigger.py
@@ -71,13 +71,13 @@ class GlobalSearchTrigger(Trigger):
         
         
         if input.get("is_delete") == True:
+            # Collection relationships being removed
+            mode = "delete"
+            my.update_collection_keywords(mode, base_search_type, input)
             if sobject:
-                # Collection relationships being removed
-                mode = "delete"
-                my.update_collection_keywords(mode, base_search_type, input)
-
                 sobject.delete()
             return
+
         # Collection relationships being created or added
         elif input.get("is_insert"):
             mode = "insert"
@@ -314,8 +314,6 @@ class GlobalSearchTrigger(Trigger):
         parent_sobject = Search.get_by_code(asset_stype, parent_code)
         child_sobject = Search.get_by_code(asset_stype, search_code)
         
-        # keywords of parent
-        parent_collection_keywords = parent_sobject.get_value("user_keywords")
 
         collection_keywords_dict = {}
         parent_collection_keywords_dict = {}
@@ -326,6 +324,9 @@ class GlobalSearchTrigger(Trigger):
         # Existing "collection" keywords in parent's keywords_data
         parent_keywords_data = parent_sobject.get_json_value("keywords_data", {})
 
+        # keywords of parent
+        parent_collection_keywords = parent_keywords_data.get('user')
+        
         if 'collection' in child_keywords_data:
             collection_keywords_dict = child_keywords_data.get('collection')
 


### PR DESCRIPTION
- update_collection_keywords command needs to be executed during deleting a collection relationship even though sobject is not found, because it might have been deleted in the remove/delete buttons in collection layout already
- during creating of collection relationships, the collection's name needs to be part of user keywords too