### PR TITLE
WORK-368:

### DIFF
--- a/src/config2/search_type/widget/sthpw/login_group-conf.xml
+++ b/src/config2/search_type/widget/sthpw/login_group-conf.xml
@@ -98,7 +98,7 @@
 </startup>
 
 
-  
+<!--
 <simple_search>
     <element name="hide_other_projects">
         <display class="tactic.ui.filter.ExpressionFilterElementWdg">
@@ -106,7 +106,7 @@
         </display>
     </element>
 </simple_search>
-
+-->
 
 
 <permissions>


### PR DESCRIPTION
- resolved disappearing groups error from group list wdg by commenting out the simple search filter defined in login-group conf