### PR TITLE
WORK-387:

### DIFF
--- a/src/tactic/ui/table/sobject_detail_wdg.py
+++ b/src/tactic/ui/table/sobject_detail_wdg.py
@@ -45,7 +45,7 @@ class SObjectDetailElementWdg(BaseTableElementWdg):
         'values': 'true|false',
         'order': 3
     },
-    'hide_default_elements': {
+    'show_default_elements': {
         "description": "Determine if the default element names should be hidden",
         'category': 'Options',
         'type': 'SelectWdg',
@@ -126,9 +126,9 @@ class SObjectDetailElementWdg(BaseTableElementWdg):
         tab_element_names = my.kwargs.get("tab_element_names") or ""
         detail_view = my.kwargs.get("detail_view") or ""
         
-        hide_default_elements = False
-        if my.kwargs.get("hide_default_elements") in ['true', True]:
-            hide_default_elements = True
+        show_default_elements = "true"
+        if my.kwargs.get("show_default_elements") in ['false', False]:
+            show_default_elements = "false"
 
         widget.add_behavior( {
         'type': 'click_up',
@@ -137,7 +137,7 @@ class SObjectDetailElementWdg(BaseTableElementWdg):
         'tab_element_names': tab_element_names,
         'detail_view': detail_view,
         'show_task_process': my.show_task_process,
-        'hide_default_elements': hide_default_elements,
+        'show_default_elements': show_default_elements,
         'code': code,
         'name': name,
         'label': title,
@@ -150,7 +150,7 @@ class SObjectDetailElementWdg(BaseTableElementWdg):
             tab_element_names: bvr.tab_element_names,
             show_task_process: bvr.show_task_process,
             detail_view: bvr.detail_view,
-            hide_default_elements: bvr.hide_default_elements
+            show_default_elements: bvr.show_default_elements
         };
 
         var mode = '';

--- a/src/tactic/ui/table/sobject_detail_wdg.py
+++ b/src/tactic/ui/table/sobject_detail_wdg.py
@@ -44,6 +44,13 @@ class SObjectDetailElementWdg(BaseTableElementWdg):
         'type': 'SelectWdg',
         'values': 'true|false',
         'order': 3
+    },
+    'hide_default_elements': {
+        "description": "Determine if the default element names should be hidden",
+        'category': 'Options',
+        'type': 'SelectWdg',
+        'values': 'true|false',
+        'order': 4
     }
 
     }
@@ -118,6 +125,10 @@ class SObjectDetailElementWdg(BaseTableElementWdg):
 
         tab_element_names = my.kwargs.get("tab_element_names") or ""
         detail_view = my.kwargs.get("detail_view") or ""
+        
+        hide_default_elements = False
+        if my.kwargs.get("hide_default_elements") in ['true', True]:
+            hide_default_elements = True
 
         widget.add_behavior( {
         'type': 'click_up',
@@ -126,6 +137,7 @@ class SObjectDetailElementWdg(BaseTableElementWdg):
         'tab_element_names': tab_element_names,
         'detail_view': detail_view,
         'show_task_process': my.show_task_process,
+        'hide_default_elements': hide_default_elements,
         'code': code,
         'name': name,
         'label': title,
@@ -137,7 +149,8 @@ class SObjectDetailElementWdg(BaseTableElementWdg):
             use_parent: bvr.use_parent,
             tab_element_names: bvr.tab_element_names,
             show_task_process: bvr.show_task_process,
-            detail_view: bvr.detail_view
+            detail_view: bvr.detail_view,
+            hide_default_elements: bvr.hide_default_elements
         };
 
         var mode = '';

--- a/src/tactic/ui/tools/sobject_wdg.py
+++ b/src/tactic/ui/tools/sobject_wdg.py
@@ -554,10 +554,20 @@ class SObjectDetailWdg(BaseRefreshWdg):
 
         title = my.search_type.split("/")[-1].title()
 
+        detail_view = my.kwargs.get("detail_view")
+        if not detail_view:
+            detail_view = ""
+
+        hide_default_elements = False
+        if my.kwargs.get("hide_default_elements") in [True, 'true']:
+            hide_default_elements = True
+
         values = {
                 'search_key': search_key,
                 'pipeline_code': my.pipeline_code,
                 'search_type': my.search_type,
+                'detail_view': detail_view,
+                'hide_default_elements': hide_default_elements
         }
 
         config_xml = []
@@ -633,6 +643,8 @@ class SObjectDetailWdg(BaseRefreshWdg):
                 <element name="info">
                   <display class='tactic.ui.tools.SObjectDetailInfoWdg'>
                     <search_key>%(search_key)s</search_key>
+                    <detail_view>%(detail_view)s</detail_view>
+                    <hide_default_elements>%(hide_default_elements)s</hide_default_elements>
                   </display>
                 </element>
                 ''' % values)
@@ -979,6 +991,13 @@ class SObjectDetailWdg(BaseRefreshWdg):
                 view = "edit"
 
             element_names = ['code', 'name','description']
+
+            # Make element_names empty if user desides to hide the default elements
+            hide_default_elements = my.kwargs.get("hide_default_elements")
+            
+            if hide_default_elements in ['true', 'True', True]:
+                element_names = []
+
             config = WidgetConfigView.get_by_search_type(search_type=my.full_search_type, view=view)
             config_element_names = config.get_element_names()
             for x in config_element_names:

--- a/src/tactic/ui/tools/sobject_wdg.py
+++ b/src/tactic/ui/tools/sobject_wdg.py
@@ -558,16 +558,16 @@ class SObjectDetailWdg(BaseRefreshWdg):
         if not detail_view:
             detail_view = ""
 
-        hide_default_elements = False
-        if my.kwargs.get("hide_default_elements") in [True, 'true']:
-            hide_default_elements = True
+        show_default_elements = True
+        if my.kwargs.get("show_default_elements") in [False, 'False', 'false']:
+            show_default_elements = False
 
         values = {
                 'search_key': search_key,
                 'pipeline_code': my.pipeline_code,
                 'search_type': my.search_type,
                 'detail_view': detail_view,
-                'hide_default_elements': hide_default_elements
+                'show_default_elements': show_default_elements
         }
 
         config_xml = []
@@ -644,7 +644,7 @@ class SObjectDetailWdg(BaseRefreshWdg):
                   <display class='tactic.ui.tools.SObjectDetailInfoWdg'>
                     <search_key>%(search_key)s</search_key>
                     <detail_view>%(detail_view)s</detail_view>
-                    <hide_default_elements>%(hide_default_elements)s</hide_default_elements>
+                    <show_default_elements>%(show_default_elements)s</show_default_elements>
                   </display>
                 </element>
                 ''' % values)
@@ -993,9 +993,9 @@ class SObjectDetailWdg(BaseRefreshWdg):
             element_names = ['code', 'name','description']
 
             # Make element_names empty if user desides to hide the default elements
-            hide_default_elements = my.kwargs.get("hide_default_elements")
+            show_default_elements = my.kwargs.get("show_default_elements")
             
-            if hide_default_elements in ['true', 'True', True]:
+            if show_default_elements in ['false', 'False', False]:
                 element_names = []
 
             config = WidgetConfigView.get_by_search_type(search_type=my.full_search_type, view=view)


### PR DESCRIPTION
- added a kwarg to sobject details which allows users to hide the default element_names (ie. name description code)
- mainly used for order_code
- fixed detail_view error (was not being passed in earlier)