### PR TITLE
BRANCH BASE-388b:

### DIFF
--- a/src/tactic/ui/tools/trigger_wdg.py
+++ b/src/tactic/ui/tools/trigger_wdg.py
@@ -1639,7 +1639,7 @@ class TriggerCreateCbk(BaseTriggerEditCbk):
     def execute(my):
 
         outputs = my.kwargs.get("output")
-        if isinstance(outputs, basestring) and output:
+        if isinstance(outputs, basestring) and outputs:
             outputs = [outputs]
         elif isinstance(outputs, list):
             outputs = [p for p in outputs if p]


### PR DESCRIPTION
  fixed the typo in variable output in TriggerCreateCbk