### PR TITLE
BRANCH WORK-489:

### DIFF
--- a/src/pyasm/widget/upload_server_page.py
+++ b/src/pyasm/widget/upload_server_page.py
@@ -39,7 +39,7 @@ class UploadServerWdg(Widget):
             files = []
             for i in range(0, num_files):
                 field_storage = web.get_form_value("file%s" % i)
-                if not field_storage:
+                if not field_storage or isinstance(field_storage, basestring):
                     continue
 
                 file_name = web.get_form_value("file_name%s"% i)
@@ -70,6 +70,10 @@ class UploadServerWdg(Widget):
 
 
     def get_file_name(my, field_storage):
+
+        # handle some spoofed upload case
+        if isinstance(field_storage, basestring):
+            return field_storage
 
         file_name = field_storage.filename
 
@@ -132,6 +136,8 @@ class UploadServerWdg(Widget):
         is uploaded in html5 mode.
         TODO: This shortcut cannot be used with upload_multipart.py 
         '''
+        if isinstance(field_storage, basestring):
+            return
         path = field_storage.get_path()
         
         # Base 64 encoded files are uploaded and decoded in FileUpload

--- a/src/tactic/ui/tools/ingest_wdg.py
+++ b/src/tactic/ui/tools/ingest_wdg.py
@@ -1597,7 +1597,7 @@ class IngestUploadCmd(Command):
 
 
             if filename.startswith("search_key:"):
-                mode = "single"
+                mode = "search_key"
                 tmp, search_key = filename.split("search_key:")
                 snapshot = Search.get_by_search_key(search_key)
                 if snapshot.get_search_type() == "sthpw/snapshot":
@@ -1707,7 +1707,7 @@ class IngestUploadCmd(Command):
                 if relative_dir and sobject.column_exists("relative_dir"):
                     sobject.set_value("relative_dir", relative_dir)
 
-            if mode == "single":
+            if mode == "search_key":
                 path = lib_path
 
             elif relative_dir:
@@ -1715,7 +1715,15 @@ class IngestUploadCmd(Command):
             else:
                 path = filename
 
-            file_keywords = Common.extract_keywords_from_path(path)
+            # Don't want the keywords being extracted from lib_path, extract the relative dir path instead
+            # Using new_filename because it is the filename without version numbers
+            if relative_dir:
+                path_for_keywords = "%s/%s" % (relative_dir, new_filename)
+            else:
+                path_for_keywords = new_filename
+
+            file_keywords = Common.extract_keywords_from_path(path_for_keywords)            
+            
             # Extract keywords from the path to be added to keywords_data, 
             # if ignore_path_keywords is found, remove the specified keywords
             # from the path keywords
@@ -1756,7 +1764,7 @@ class IngestUploadCmd(Command):
                 first_filename = non_seq_filenames_dict.get(filename)[0]
                 last_filename = non_seq_filenames_dict.get(filename)[-1]
                 file_path = "%s/%s" % (base_dir, first_filename)
-            elif mode == "single":
+            elif mode == "search_key":
                 file_path = path
             else:
                 file_path = "%s/%s" % (base_dir, filename)
@@ -1894,18 +1902,19 @@ class IngestUploadCmd(Command):
                 file_path = "%s/%s" % (base_dir, filename)
                 server.group_checkin(search_key, context, file_path, file_range, mode='uploaded')
             else: 
-                from pyasm.checkin import FileCheckin
-                if mode == "single":
+                
+                if mode == "search_key":
                     # copy the file to a temporary location
                     tmp_dir = Environment.get_tmp_dir()
                     tmp_path = "%s/%s" % (tmp_dir, new_filename)
                     shutil.copy(file_path, tmp_path)
-
-                    checkin = FileCheckin(sobject, tmp_path, process=process)
-                    checkin.execute()
+                    # auto create icon
+                    server.simple_checkin(search_key, context, tmp_path, process=process, mode='move')
+                    
                 elif my.kwargs.get("base_dir"):
-                    checkin = FileCheckin(sobject, file_path, context=context, process=process)
-                    checkin.execute()
+                    # auto create icon
+                    server.simple_checkin(search_key, context, file_path, process=process, mode='move')
+                    
                 else:
                     server.simple_checkin(search_key, context, filename, process=process, mode='uploaded')
 
@@ -1952,7 +1961,7 @@ class IngestUploadCmd(Command):
         if file_sobjects and update_mode in ['true', True] and len(sobjects) > 1:
             raise TacticException('Multiple files with the same name as "%s" already exist. Uncertain as to which file to update. Please individually update each file.' % new_filename)
         elif file_sobjects:
-            raise TacticException('A file with the same name as "%s" already exists in the path "%s". Please rename the file and ingest again.' % (new_filename, relative_dir))
+            raise TacticException('A file with the same name as "%s" already exists in the file table with path "%s". Please rename the file and ingest again.' % (new_filename, relative_dir))
 
     def natural_sort(my,l):
         '''


### PR DESCRIPTION
    added condition to handle spoofed upload where field_storage is just a string in HTML5 Upload
    renamed single mode as search_key mode
    changed FileCheckin() call to server.simple_checkin(mode=move) so they can create icons by default if applicable
    added fix for keywords extraction for the Push to Asset Library case (from Sean)