### PR TITLE
WORK-268_extended:

### DIFF
--- a/src/tactic/command/global_search_trigger.py
+++ b/src/tactic/command/global_search_trigger.py
@@ -111,13 +111,12 @@ class GlobalSearchTrigger(Trigger):
             
             update_data = input.get("update_data")
 
-            # If Relative dir is changed, update path keywords
-            if "relative_dir" in update_data and not input.get("mode") == "insert":
-                new_path = update_data.get("relative_dir")
+            # If Relative dir is changed or file is renamed, update path keywords
+            if "relative_dir" in update_data or "name" in update_data and not input.get("mode") == "insert":
+                file_path = input.get("sobject").get("relative_dir")
                 asset_name = input.get("sobject").get("name")
-                if asset_name:
-                    new_path = "%s/%s" % (new_path, asset_name)
-                path_keywords = Common.extract_keywords_from_path(new_path)
+
+                path_keywords = Common.extract_keywords_from_path(file_path)
 
                 path_keywords.append(asset_name.lower())
                 project_code = Project.get_project_code()


### PR DESCRIPTION
- this fix is to take care of filename rename in the repo, and then update path keywords
- i removed celton's fix because the .append(asset_name) takes care of including the name in the path keywords
- added in another condition in the same if statement to detech name change
- added all of the update_data.gets to input.get("sobject").get because sobject will always contain the most updated values anyway (so it works for both relative dir change and filename change