### PR TITLE
BRANCH BASE-411:

### DIFF
--- a/src/bin/monitor_dev.py
+++ b/src/bin/monitor_dev.py
@@ -24,6 +24,10 @@ if __name__ == '__main__':
     monitor = TacticMonitor(num_processes)
     monitor.set_dev(True) 
     #monitor.set_check_interval(0)
+    monitor.mode = 'init'
     monitor.execute()
+    monitor.mode = 'monitor'
+    monitor.execute()
+ 
 
 

--- a/src/install/service/win32_service.py
+++ b/src/install/service/win32_service.py
@@ -43,8 +43,8 @@ class WinService(object):
         my.monitor.mode = "init"
         my.monitor.execute()
 
-    def monitor(my):
-        my.monitor.mode = 'monitor'
+    def run(my):
+        my.monitor.mode = "monitor"
         my.monitor.execute()
     
 def write_stop_monitor():
@@ -119,7 +119,7 @@ class TacticService(win32serviceutil.ServiceFramework):
         service.init()
         self.ReportServiceStatus(win32service.SERVICE_RUNNING)
         win32event.WaitForSingleObject(self.stop_event, win32event.INFINITE) 
-        service.monitor()
+        service.run()
         # monitor() needs to run after... 
      
     def SvcStop(self): 

--- a/src/pyasm/security/security.py
+++ b/src/pyasm/security/security.py
@@ -313,6 +313,7 @@ class Login(SObject):
 
         login = SearchType.create("sthpw/login")
         login.set_value("login", user_name)
+        login.set_value("upn", user_name)
 
         # encrypt the password
         encrypted = hashlib.md5(password).hexdigest()

--- a/src/pyasm/web/monitor.py
+++ b/src/pyasm/web/monitor.py
@@ -376,8 +376,10 @@ class TacticSchedulerThread(threading.Thread):
 
         from pyasm.biz import Project
         search = Search("sthpw/project")
+        # only requires the admin project
+        search.add_filter('code', 'sthpw', op='!=')
         projects = search.get_sobjects()
-
+        
         # get the all of the timed triggers
         #search = Search("sthpw/timed_trigger")
         #search.add_filter("type", "timed")
@@ -551,7 +553,9 @@ class TacticMonitor(object):
     def watch_folder_cleanup(my, base_dir):
         '''removes old action files from previous watch
         folder processes.'''
-        files = os.listdir(base_dir)
+        files = []
+        if os.path.exists(base_dir):
+            files = os.listdir(base_dir)
         for file_name in files:
             base_file, ext = os.path.splitext(file_name)
             if ext in [".lock", ".checkin"]:
@@ -565,7 +569,9 @@ class TacticMonitor(object):
             my._execute()
 
     def _execute(my):
-        '''if mode is normal, this runs both the main startup logic plus monitor'''
+        '''if mode is normal which is fine in Linux, 
+           this runs both the main startup logic plus monitor'''
+        
         from pyasm.security import Batch
         Batch(login_code="admin")
 


### PR DESCRIPTION
   only clean up watch folder if it exists
   added upn to Login.create()
   skipped sthpw project when initializing the scheduler trigger that runs on a user-defined interval
   updated monitor_dev.py to run in init mode followed by monitor mode