### PR TITLE
BRANCH BASE-417:

### DIFF
--- a/src/install/data/__init__.py
+++ b/src/install/data/__init__.py
@@ -10,7 +10,7 @@
 #
 #
 
-__all__ = ['get_install_dir', 'get_site_dir', 'get_data_dir']
+__all__ = ['get_install_dir', 'get_site_dir', 'get_data_dir', 'get_temp_dir']
 
 import os, sys
 
@@ -27,6 +27,11 @@ def get_site_dir():
 def get_data_dir():
     return data_dir
 
+def get_temp_dir():
+    from pyasm.common import Environment 
+    temp_dir = Environment.get_tmp_dir()
+
+    return temp_dir
 
 # Defualt Tactic Installations
 from tactic_paths import *

--- a/src/install/service/tactic
+++ b/src/install/service/tactic
@@ -17,6 +17,8 @@
 TACTIC_INSTALL_DIR=`python -c 'import tacticenv; print tacticenv.get_install_dir()'`
 TACTIC_SITE_DIR=`python -c 'import tacticenv; print tacticenv.get_site_dir()'`
 TACTIC_DATA_DIR=`python -c 'import tacticenv; print tacticenv.get_data_dir()'`
+TACTIC_TEMP_DIR=`python -c 'import tacticenv; print tacticenv.get_temp_dir()'`
+
 
 echo "TACTIC_INSTALL_DIR = $TACTIC_INSTALL_DIR"
 echo "TACTIC_SITE_DIR = $TACTIC_SITE_DIR"
@@ -24,10 +26,11 @@ echo "TACTIC_DATA_DIR = $TACTIC_DATA_DIR"
 echo
 
 # Some variables
-TACTIC_USER=apache
+TACTIC_USER=tactic
 PYTHON=/usr/bin/python
 export PYTHON
 PID_FILE=/var/run/tactic.pid
+STOP_MONITOR_FILE=$TACTIC_TEMP_DIR/log/stop.monitor
 LOG=/var/log/tactic
 
 APP_DIR=$TACTIC_INSTALL_DIR/src/bin
@@ -110,13 +113,14 @@ case "$1" in
 	    echo `kill $PID >> $LOG 2>&1`
             if kill $PID >> $LOG 2>&1 ; then
                 i=0
-                for line in $(ps axw|grep startup.py |grep -v grep|awk '{print $1}'); do
+                for line in $(ps axw|grep -E "startup.py|watch_drop_folder.py" |grep -v grep|awk '{print $1}'); do
                     STARTUP_PIDS[$i]=$line
                     i=`expr $i + 1`
                 done
             
                 if [ ${#STARTUP_PIDS[@]} -gt 0 ]; then
-                    #echo -n $"killing pids:  ${STARTUP_PIDS[*]}"
+                    echo "monitor"  > $STOP_MONITOR_FILE
+                    chown $TACTIC_USER.$TACTIC_USER $STOP_MONITOR_FILE
                     kill -9 ${STARTUP_PIDS[*]}
                     /bin/rm $PID_FILE
                     sleep 2

--- a/src/install/service/win32_service.py
+++ b/src/install/service/win32_service.py
@@ -52,52 +52,20 @@ def write_stop_monitor():
     log_dir = "%s/log" % Environment.get_tmp_dir()
     if not os.path.exists(log_dir):
         os.makedirs(log_dir)
-
+    
+   
     file = open("%s/stop.monitor" % log_dir, "w")
     pid = os.getpid()
     file.write(str(pid))
     file.close()
 
 def stop():
-    #startup.stop() 
-    log_dir = "%s/log" % Environment.get_tmp_dir()
-    files = os.listdir(log_dir)
-    ports = []
-    watch_folders = []
+   
     write_stop_monitor()
     
     import time
-    time.sleep(5)
-
-    for filename in files:
-        base, ext = os.path.splitext(filename)
-        if base == 'pid':
-            ports.append(ext[1:])
-        elif base == 'watch_folder':
-            watch_folders.append(ext[1:])
-    
-    for port in ports:
-        try:
-            file_name = "%s/pid.%s" % (log_dir,port)
-            file = open(file_name, "r")
-            pid = file.readline().strip()
-            os.system('taskkill /F /PID %s'%pid)
-            file.close()
-        except IOError, e:
-            print "Error opening file [%s]" %file_name
-            continue
-
-    # kill watch folder processes
-    for watch_folder in watch_folders:
-        try:
-            filename = "%s/watch_folder.%s" % (log_dir, watch_folder)
-            f = open(filename, "r")
-            pid = f.readline()
-            f.close()
-            os.system('taskkill /F /PID %s' % pid)
-        except IOError, e:
-            print "Error handling processes for watch folder [%s]." % watch_folder
-
+    time.sleep(3)
+    # let monitor.py handle killing of start_up and watch_folder
  
 class TacticService(win32serviceutil.ServiceFramework): 
     '''NT Service.'''
@@ -118,9 +86,9 @@ class TacticService(win32serviceutil.ServiceFramework):
         service = WinService()
         service.init()
         self.ReportServiceStatus(win32service.SERVICE_RUNNING)
-        win32event.WaitForSingleObject(self.stop_event, win32event.INFINITE) 
         service.run()
-        # monitor() needs to run after... 
+        # run() needs to run after SERVICE_RUNNING... 
+        win32event.WaitForSingleObject(self.stop_event, win32event.INFINITE) 
      
     def SvcStop(self): 
         self.ReportServiceStatus(win32service.SERVICE_STOP_PENDING) 

--- a/src/pyasm/web/monitor.py
+++ b/src/pyasm/web/monitor.py
@@ -49,6 +49,7 @@ class BaseProcessThread(threading.Thread):
         my.kill_interval = 30 + random.randint(0,30)
         my.kill_interval = 1
         my.end = False
+        my.port = None
         super(BaseProcessThread,my).__init__()
 
     def run(my):
@@ -62,10 +63,11 @@ class BaseProcessThread(threading.Thread):
             time.sleep(1)
             
             if my.end:
-                print "Stopping %s ..." % my.get_title()
+                #print "Stopping %s ..." % my.get_title()
                 break
             else:
-                print "Restarting %s ..." % my.get_title()
+                #print "Restarting %s ..." % my.get_title()
+                pass
 
     def get_title(my):
         return "No Title"
@@ -80,13 +82,24 @@ class BaseProcessThread(threading.Thread):
  
         f = open('%s/monitor.log' % log_dir,'a')
         import datetime
-        f.write('Time: %s\n\n' %datetime.datetime.now())
+        f.write('\nTime: %s\n\n' %datetime.datetime.now())
         f.write('%s\n'%msg)
 
     def check(my):
         pass
 
 
+    def _get_pid(my):
+        '''Get PID from a file'''
+        log_dir = "%s/log" % Environment.get_tmp_dir()
+        pid_path = "%s/pid.%s" % (log_dir, my.port)
+        pid = 0
+        if os.path.exists(pid_path):
+            file = open(pid_path, "r")
+            pid = file.read()
+            file.close()
+        return pid
+       
     def _check(my):
 
         # This will kill the TACTIC process 
@@ -99,7 +112,6 @@ class BaseProcessThread(threading.Thread):
                 file = open("%s/pid.%s" % (log_dir,my.port), "r")
                 pid = file.read()
                 file.close()
-                print "Killing process: ", pid
                 Common.kill(pid)
 
                 #my.run()
@@ -113,19 +125,16 @@ class BaseProcessThread(threading.Thread):
         try:
             response = my.check()
         except IOError, e:
-            print "Tactic IOError: ", str(e)
 
-            # Kill if unresponsive ... (only on linux)
-            log_dir = "%s/log" % Environment.get_tmp_dir()
-            file = open("%s/pid.%s" % (log_dir,my.port), "r")
-            pid = file.read()
-            file.close()
-            print "Killing process: ", pid
-            
-            Common.kill(pid) 
+            pid = my._get_pid() 
+            if pid:
+                Common.kill(pid)
         else:
             if response and response != "OK":
-                my.end = True
+                #my.end = True
+                pid = my._get_pid() 
+                if pid:
+                    Common.kill(pid)
                 return
 
         '''
@@ -169,14 +178,12 @@ class TacticThread(BaseProcessThread):
         os.system('%s %s' % (exec_file, my.port) )
 
 
-
     def check(my):
-        
         f = urllib.urlopen("http://localhost:%s/test" % my.port )
         response = f.readlines()
-        
         f.close()
         return response[0]
+
 
 
 
@@ -207,7 +214,7 @@ class CustomPythonProcessThread(BaseProcessThread):
 
             if char == "\n":
                 line = "".join(buffer)
-                print line
+                #print line
 
             buffer.append(char)
  
@@ -327,9 +334,7 @@ class TacticTimedThread(threading.Thread):
 
             # go through each trigger
             for timed_trigger in timed_triggers:
-                print timed_trigger
                 if not timed_trigger.is_ready():
-                    print "... not ready"
                     continue
 
                 if timed_trigger.is_in_separate_thread():
@@ -348,7 +353,7 @@ class TacticTimedThread(threading.Thread):
 
 
             if my.end:
-                print "Stopping timed thread"
+                #print "Stopping timed thread"
                 break
 
 
@@ -356,17 +361,20 @@ class TacticTimedThread(threading.Thread):
 class TacticSchedulerThread(threading.Thread):
 
     def __init__(my):
+        my.dev_mode = False
         super(TacticSchedulerThread,my).__init__()
 
     def _check(my):
         pass
 
+    def set_dev(my, mode):
+        my.dev_mode = mode
 
     def run(my):
         import time
         time.sleep(3)
 
-        print "Starting Scheduler ...."
+        #print "Starting Scheduler ...."
 
         # NOTE: not sure why we have to do a batch here
         from pyasm.security import Batch
@@ -379,7 +387,7 @@ class TacticSchedulerThread(threading.Thread):
         # only requires the admin project
         search.add_filter('code', 'sthpw', op='!=')
         projects = search.get_sobjects()
-        
+
         # get the all of the timed triggers
         #search = Search("sthpw/timed_trigger")
         #search.add_filter("type", "timed")
@@ -391,7 +399,7 @@ class TacticSchedulerThread(threading.Thread):
                 search.add_filter("event", "schedule")
                 timed_trigger_sobjs = search.get_sobjects()
             except Exception, e:
-                print "WARNING: ", e
+                #print "WARNING: ", e
                 continue
 
             # example
@@ -432,7 +440,7 @@ class TacticSchedulerThread(threading.Thread):
                     
                 timed_triggers.append(timed_trigger)
 
-            if has_triggers:
+            if has_triggers and my.dev_mode:
                 print "Found [%s] scheduled triggers in project [%s]..." % (len(timed_triggers), project_code)
 
         from tactic.command import Scheduler, SchedulerTask
@@ -455,7 +463,6 @@ class TacticSchedulerThread(threading.Thread):
                     Project.set_project(my.project_code)
                     timed_triggers[my.index].execute()
                 except Exception, e:
-                    print "Error running trigger"
                     raise
                 finally:
                     DbContainer.close_thread_sql()
@@ -544,6 +551,15 @@ class TacticMonitor(object):
         my.mode = 'normal'
 
 
+    def write_log(my, msg):
+        '''for debugging only'''
+        log_dir = "%s/log" % Environment.get_tmp_dir()
+ 
+        f = open('%s/monitor.log' % log_dir,'a')
+        import datetime
+        f.write('\nTime: %s\n\n' %datetime.datetime.now())
+        f.write('%s\n'%msg)
+
     def set_check_interval(my, check_interval):
         my.check_interval = check_interval
 
@@ -553,14 +569,13 @@ class TacticMonitor(object):
     def watch_folder_cleanup(my, base_dir):
         '''removes old action files from previous watch
         folder processes.'''
-        files = []
         if os.path.exists(base_dir):
             files = os.listdir(base_dir)
-        for file_name in files:
-            base_file, ext = os.path.splitext(file_name)
-            if ext in [".lock", ".checkin"]:
-                path = "%s/%s" % (base_dir, file_name)
-                os.remove(path)
+            for file_name in files:
+                base_file, ext = os.path.splitext(file_name)
+                if ext in [".lock", ".checkin"]:
+                    path = "%s/%s" % (base_dir, file_name)
+                    os.remove(path)
              
     def execute(my):
         if my.mode == 'monitor':
@@ -569,9 +584,7 @@ class TacticMonitor(object):
             my._execute()
 
     def _execute(my):
-        '''if mode is normal which is fine in Linux, 
-           this runs both the main startup logic plus monitor'''
-        
+        '''if mode is normal, this runs both the main startup (init) logic plus monitor'''
         from pyasm.security import Batch
         Batch(login_code="admin")
 
@@ -748,6 +761,7 @@ class TacticMonitor(object):
         start_scheduler = Config.get_value("services", "scheduler")
         if start_scheduler == 'true':
             tactic_scheduler_thread = TacticSchedulerThread()
+            tactic_scheduler_thread.set_dev(my.dev_mode)
             tactic_scheduler_thread.start()
             tactic_threads.append(tactic_scheduler_thread)
 
@@ -771,7 +785,6 @@ class TacticMonitor(object):
     def monitor(my):
         '''monitor the tactic threads'''
         start_time = time.time()
-        
         log_dir = "%s/log" % Environment.get_tmp_dir()
         
         while 1:
@@ -779,6 +792,8 @@ class TacticMonitor(object):
             try:
                 monitor_stop = os.path.exists('%s/stop.monitor'%log_dir)
                 if monitor_stop:
+                    for tactic_thread in my.tactic_threads:
+					    tactic_thread.end = True
                     break
                 if my.check_interval:
                     # don't check threads during startup period
@@ -791,11 +806,12 @@ class TacticMonitor(object):
                             my.startup = False
 
                 else:
-                    # FIXME: break for now (for windows service)
+                    # Windows Service does not need this 0 check_interval
+                    # any more.  
                     break
 
             except KeyboardInterrupt, e:
-                print "Keyboard interrupt ... exiting Tactic"
+                #print "Keyboard interrupt ... exiting Tactic"
                 for tactic_thread in my.tactic_threads:
                     tactic_thread.end = True
                     end = True
@@ -803,9 +819,45 @@ class TacticMonitor(object):
             if end:
                 break
 
-        #print "exiting Tactic"
-        #sys.exit(0)
+        my.final_kill()
+        
 
+    def final_kill(my):
+        '''Kill the startup and watch_folder processes. This is used primarily in Windows Service.
+           Linux service should have actively killed the processes already'''
+        log_dir = "%s/log" % Environment.get_tmp_dir()
+        files = os.listdir(log_dir)
+        ports = []
+        watch_folders = []
+
+        for filename in files:
+            base, ext = os.path.splitext(filename)
+            if base == 'pid':
+                ports.append(ext[1:])
+            elif base == 'watch_folder':
+                watch_folders.append(ext[1:])
+
+    
+        for port in ports:
+            try:
+                file_name = "%s/pid.%s" % (log_dir,port)
+                file = open(file_name, "r")
+                pid = file.readline().strip()
+                file.close()
+                Common.kill(pid)
+            except IOError, e:
+                continue
+
+        # kill watch folder processes
+        for watch_folder in watch_folders:
+            try:
+                filename = "%s/watch_folder.%s" % (log_dir, watch_folder)
+                f = open(filename, "r")
+                pid = f.readline()
+                f.close()
+                Common.kill(pid)
+            except IOError, e:
+                continue
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
   added get_temp_dir() to new installation for __init__.py in tacticenv
   made Linux service kill watch_drop_folder.py as well as startup.py
   improved Windows Service reliability
   if a test request is non-responsive, kill the thread and let it respawn
   made Windows service primarily rely on monitor.py to take care of the killing of the startup and watch_drop_folder processes