### PR TITLE
BRANCH BASE-420:

### DIFF
--- a/src/pyasm/search/database_impl.py
+++ b/src/pyasm/search/database_impl.py
@@ -2972,7 +2972,7 @@ class SqliteImpl(PostgresImpl):
         else:
             sql = DbContainer.get(db_resource)
 
-        query = "PRAGMA table_info(%s)" % table
+        query = 'PRAGMA table_info("%s")' % table
         results = sql.do_query(query)
 
         # data return is a list of the following


### PR DESCRIPTION
  double quoted table name in Sqlite implementation calling of PRAGMA table_info()