### PR TITLE
BRANCH BASE-330:

### DIFF
--- a/src/tactic/ui/tools/pipeline_wdg.py
+++ b/src/tactic/ui/tools/pipeline_wdg.py
@@ -4415,12 +4415,14 @@ class PipelineEditorWdg(BaseRefreshWdg):
         var wrapper = editor_top.getElement(".spt_pipeline_wrapper");
         spt.pipeline.init_cbk(wrapper);
 
-        spt.pipeline.delete_selected();
 
         var nodes = spt.pipeline.get_selected_nodes();
-        for (var i = 0; i < nodes.length; i++) {
-            spt.pipeline.remove_node(nodes[i]);
-        }
+        
+        spt.pipeline.remove_nodes(nodes);
+        
+        // this targets connectors only
+        spt.pipeline.delete_selected();
+      
         '''
         } )
 


### PR DESCRIPTION
   removed the redundant z-index set to the paint in Project Workflow
   added spt.pipeline.select_nodes_by_box() to Project Workflow
   fixed issues where drawing a box with Shift only select connectors
   made the dangling connector when deleting down to one process node
   made the delete button delete both connectors and nodes when they are both selected