### PR TITLE
fixed tools overwrite

### DIFF
--- a/src/tactic/command/plugin.py
+++ b/src/tactic/command/plugin.py
@@ -1011,8 +1011,8 @@ class PluginInstaller(PluginBase):
 
                 # import the backup data back
                 backup_path = "%s/backup/%s.spt" % (my.plugin_dir, search_type.replace("/", "_"))
-                tools = PluginTools(plugin_dir=my.plugin_dir, verbose=my.verbose)
-                tools.import_data(backup_path)
+                tools_backup = PluginTools(plugin_dir=my.plugin_dir, verbose=my.verbose)
+                tools_backup.import_data(backup_path)
 
 
             elif node_name == 'sobject':


### PR DESCRIPTION
When importing plugins or templates the tools object was overwritten at the first search_type entry in manifest.xml when trying to import backup/"search_type".spt as a consequence all following nodes where imported without executing any callback or filter