### PR TITLE
Table "pipeline" never had a "type" column

### DIFF
--- a/src/pyasm/search/upgrade/project/sthpw_upgrade.py
+++ b/src/pyasm/search/upgrade/project/sthpw_upgrade.py
@@ -28,7 +28,7 @@ class SthpwUpgrade(BaseUpgrade):
 
     def upgrade_v4_6_0_a01_002(my):
         my.run_sql('''
-        ALTER TABLE "pipeline" ALTER COLUMN "type" TYPE varchar(256);
+        ALTER TABLE "pipeline" ADD COLUMN "type" varchar(256);
         ''')
 
 


### PR DESCRIPTION
trying to ALTER COLUMN would fail leaving the table without a "type" column and workflow editor would not work