### PR TITLE
got rid of two SyntaxWarning

### DIFF
--- a/src/pyasm/search/upgrade/project/sthpw_upgrade.py
+++ b/src/pyasm/search/upgrade/project/sthpw_upgrade.py
@@ -136,7 +136,7 @@ class SthpwUpgrade(BaseUpgrade):
             return zonenames
 
         # add time zone names to timezone prefernce if it does not exist
-        from dateutil.tz import *
+        from dateutil import tz
         from pyasm.search import Search
         pref_list_id = Search.eval("@GET(sthpw/pref_list['key','timezone'].id)")
         if not pref_list_id:
@@ -144,7 +144,7 @@ class SthpwUpgrade(BaseUpgrade):
             timezones = []
             for name in names:
                 try:
-                    gettz(name)
+                    tz.gettz(name)
                     timezones.append(name)
                 except:
                     continue

--- a/src/pyasm/search/upgrade/upgrade_db.py
+++ b/src/pyasm/search/upgrade/upgrade_db.py
@@ -18,6 +18,10 @@ import sys, re, getopt, os, shutil
 from pyasm.search import Search, SObject, DbContainer, Sql
 from pyasm.common import Container, Environment
 
+# load all the default modules
+from pyasm.search.upgrade.project import *
+
+ 
 __all__ = ['Upgrade']
 
 class Upgrade(object):
@@ -104,10 +108,6 @@ class Upgrade(object):
                 class_name = "%s%sUpgrade" % (database_type,namespace.capitalize())
                 exec("%s = module.%s" % (class_name, class_name) )
 
-
-
-        # load all the default modules
-        from pyasm.search.upgrade.project import *
 
         for project in projects:
             
@@ -247,9 +247,4 @@ class Upgrade(object):
                     print "Default project template files have been updated."
                 else:
                     print "There was a problem copying the default template files to <TACTIC_DATA_DIR>/templates."
-
-
-    
-
-
 


### PR DESCRIPTION
got rid of two "SyntaxWarning: import * only allowed at module level" during installation