### PR TITLE
BRANCH 4.6: updated it so that a return value of "false" or False in …

### DIFF
--- a/src/pyasm/command/subprocess_trigger.py
+++ b/src/pyasm/command/subprocess_trigger.py
@@ -199,17 +199,30 @@ class ScriptTrigger(Handler):
         input_data = self.get_input_data()
         trigger.set_input(input_data)
 
-
-
         try:
             trigger.execute()
 
-            self.set_pipeline_status("complete")
+            info = trigger.get_info()
+            result = info.get("result")
+            if result is not None:
+
+                # map booleans to a message
+                if result in ['true', True]:
+                    result = 'complete'
+
+                elif result in ['false', False]:
+                    result = 'revise'
+
+                self.set_pipeline_status(result)
+            else:
+                self.set_pipeline_status("complete")
 
 
         except Exception as e:
             #self.set_pipeline_status("error", {"error": str(e)})
-            self.set_pipeline_status("reject", {"error": str(e)})
+
+
+            self.set_pipeline_status("revise", {"error": str(e)})
 
             import sys,traceback
 


### PR DESCRIPTION
…a subprocess

command is intepreted as a "revise" message to the workflow engine
- also, if there is a task on a node, then a "revise" message will not push back.
- reject always pushes back