### PR TITLE
When modifying a task (both assignment and status change) on the web gui with tactic.ui.table.TaskElementWdg an exeception is generated

### DIFF
--- a/src/tactic/ui/panel/edit_cmd.py
+++ b/src/tactic/ui/panel/edit_cmd.py
@@ -154,7 +154,7 @@ class EditCmd(Command):
         default_elements = []
 
         from pyasm.widget.widget_config import WidgetConfigView, WidgetConfig
-        tmp_config = WidgetConfigView.get_by_search_type(self.search_type, self.view, layout="EditWdg")
+        tmp_config = WidgetConfigView.get_by_search_type(self.search_type, self.view)
 
         tmp_element_names = tmp_config.get_element_names()
 


### PR DESCRIPTION
This PR is in part a bug report, I found how to fix it but reverts a change made in Commit: d9405d0 on Nov 19, 2017 which I don't entirely understand. Just delete this PR if the change is part of an ongoing development!

Bug: When modifying a task (both assignment and status change) on the web gui with tactic.ui.table.TaskElementWdg this exeception is generated:

```
user: admin
timestamp: 2018-02-27 18:28:46
method: execute_cmd
ticket: fe5131205f2cb184f9cbec1914e2f217
( 'tactic.ui.panel.EditMultipleCmd',
{ 'element_names': 'name,task,task_edit,task_pipeline_panels,task_pipeline_vertical,task_pipeline_report,task_status_summary,task_status_history',
'extra_action': '[null]',
'extra_data': '[null]',
'input_prefix': '__NONE__',
'search_keys': ['test/asset?project=test&id=2'],
'update_data': '[{"task_pipeline_panels":"{\\"status|NEW|design\\":\\"Assignment\\"}"}]',
'view': 'edit_item'},
{ 'web_data': '[{"process_data":"{\\"processes\\": [\\"design\\"]}"}]'},
{ })
('Error with query (ProgrammingError): ', u'test', 'UPDATE "test"."public"."asset" SET "task_pipeline_panels" = \'{"status|NEW|design":"Assignment"}\' WHERE "id" = \'2\'')
column "task_pipeline_panels" of relation "asset" does not exist
LINE 1: UPDATE "test"."public"."asset" SET "task_pipeline_panels" = ...

--------------------------------------------------
File "/home/apache/tactic/src/pyasm/prod/service/api_xmlrpc.py", line 364, in new
cmd.execute_cmd(cmd)
File "/home/apache/tactic/src/pyasm/command/command.py", line 241, in execute_cmd
ret_val = cmd.execute()
File "/home/apache/tactic/src/pyasm/prod/service/api_xmlrpc.py", line 202, in execute
self2.results = exec_meth(self, ticket, meth, args)
File "/home/apache/tactic/src/pyasm/prod/service/api_xmlrpc.py", line 232, in exec_meth
results = meth(self, ticket, *new_args)
File "/home/apache/tactic/src/pyasm/prod/service/api_xmlrpc.py", line 5435, in execute_cmd
Command.execute_cmd(cmd)
File "/home/apache/tactic/src/pyasm/command/command.py", line 241, in execute_cmd
ret_val = cmd.execute()
File "/home/apache/tactic/src/tactic/ui/panel/edit_cmd.py", line 479, in execute
cmd.execute()
File "/home/apache/tactic/src/tactic/ui/panel/edit_cmd.py", line 140, in execute
last_sobject = self._execute_single(code, name=name)
File "/home/apache/tactic/src/tactic/ui/panel/edit_cmd.py", line 371, in _execute_single
raise SqlException(msg)

Error: An error was encountered adding this item. The error reported was [column "task_pipeline_panels" of relation "asset" does not exist
LINE 1: UPDATE "test"."public"."asset" SET "task_pipeline_panels" = ...
^
]
--------------------------------------------------
```
src/tactic/ui/panel/edit_cmd.py where the line 157 was changed from:

> tmp_config = WidgetConfigView.get_by_search_type(self.search_type, self.view)

to:

> tmp_config = WidgetConfigView.get_by_search_type(self.search_type, self.view, layout="EditWdg")

Reverting this small change makes everything work again