### PR TITLE
BRANCH 4.6: removed requirement of pipywin32 module in requirements. …

### DIFF
--- a/3rd_party/site-packages/CherryPy-14.0.0-py2.7.egg-info/requires.txt
+++ b/3rd_party/site-packages/CherryPy-14.0.0-py2.7.egg-info/requires.txt
@@ -31,8 +31,6 @@ pytest-sugar
 backports.unittest_mock
 path.py
 
-[:sys_platform == "win32"]
-pypiwin32
 
 [xcgi]
 flup


### PR DESCRIPTION
…  Doesn't seem to need it for

normal running