### PR TITLE
fix for group items in table rows collapsing/expanding items in inappropriate hiearchy levels

### DIFF
--- a/src/tactic/ui/panel/table_layout_wdg.py
+++ b/src/tactic/ui/panel/table_layout_wdg.py
@@ -6690,7 +6690,7 @@ spt.table.collapse_group = function(group_row) {
         var break_cond2 = row.getAttribute('idx') == idx
         
         
-        if (row_level == group_level) {
+        if (row_level <= group_level) {
            
            break;
 


### PR DESCRIPTION
When collapsing/expanding a nested group item in the table layout widget, only its child groups/items should disappear/appear. However, groups on a level above it (and below the item in the list) will also be affected. This is because an iterative function that goes through the items below the clicked item will only break when coming across an item of an EQUAL level. The fix is to also include items on a parent level as a break condition.

This problem never occurs if the number of group levels never exceed 2, which may be the reason this has not been encountered before.