### PR TITLE
Bug fix in setting command result description

### DIFF
--- a/src/pyasm/prod/service/api_xmlrpc.py
+++ b/src/pyasm/prod/service/api_xmlrpc.py
@@ -204,7 +204,7 @@ def get_full_cmd(self, meth, ticket, args):
                    raise ApiException("Access denied")
 
             self2.results = exec_meth(self, ticket, meth, args)
-            if isinstance(self2.results, dict) and self2.results.get("description"):
+            if meth.__name__ == "execute_cmd" and isinstance(self2.results, dict) and self2.results.get("description"):
                 self2.add_description( self2.results.get("description") )
 
             self2.sobjects = self.get_sobjects()


### PR DESCRIPTION
Use the description value only when the called method is execute_cmd.
Many commands return a sobject dictionary which contains a description key but the description field for the sobject has nothing to do with the command result description.
