### PR TITLE
Update bootstrap_schema.sql

### DIFF
--- a/src/pyasm/search/upgrade/postgresql/bootstrap_schema.sql
+++ b/src/pyasm/search/upgrade/postgresql/bootstrap_schema.sql
@@ -115,6 +115,7 @@ CREATE TABLE "trigger" (
     "project_code" character varying(256),
     "s_status" character varying(256),
     "process" character varying(256),
+    "data" character varying(256),
     CONSTRAINT "trigger_code_idx" UNIQUE ("code")
 );
 

--- a/src/pyasm/search/upgrade/postgresql/bootstrap_schema.sql
+++ b/src/pyasm/search/upgrade/postgresql/bootstrap_schema.sql
@@ -115,7 +115,7 @@ CREATE TABLE "trigger" (
     "project_code" character varying(256),
     "s_status" character varying(256),
     "process" character varying(256),
-    "data" character varying(256),
+    "data" jsonb,
     CONSTRAINT "trigger_code_idx" UNIQUE ("code")
 );
 


### PR DESCRIPTION
The "data" column is required when the trigger mode is "Separate Process, Non - Blocking"

