### PR TITLE
Improve html subtype detection for emails

### DIFF
--- a/src/pyasm/command/email_trigger.py
+++ b/src/pyasm/command/email_trigger.py
@@ -328,7 +328,7 @@ class EmailTrigger(Trigger):
             charset = 'utf-8'
             is_uni = True
         
-        if "<html>" in message:
+        if "</html>" in message:
             st = 'html'
         else:
             st = 'plain'
@@ -401,7 +401,7 @@ class SendEmail(Command):
         message = self.kwargs.get('msg')
 
         is_unicode = False
-        if "<html>" in message or paths:
+        if "</html>" in message or paths:
             st = 'html'
         else:
             st = 'plain'
@@ -927,7 +927,7 @@ class EmailTriggerTest(EmailTrigger2):
             message = Common.process_unicode_string(message) 
             charset = 'utf-8'
 
-        if "<html>" in message:
+        if "</html>" in message:
             st = 'html'
         else:
             st = 'plain'


### PR DESCRIPTION
Right now the MIME Type subtype detection for HTML texts doesn't properly work for new html tags where the language is specified (e.g., `<html lang="en">`).

I thought the easiest fix would be to just look for the closing tag instead of adding a regex or something more complex.