### PR TITLE
Open temporary file in read and write mode

### DIFF
--- a/3rd_party/site-packages/cherrypy/_cpreqbody.py
+++ b/3rd_party/site-packages/cherrypy/_cpreqbody.py
@@ -522,7 +522,7 @@ class Entity(object):
         else:
             fd, path = tempfile.mkstemp()
             self.path = path
-            fp_out = os.fdopen(fd, 'w')
+            fp_out = os.fdopen(fd, 'w+')
             return fp_out
         # /SOUTHPAW
 


### PR DESCRIPTION
**Bug**: Requests with a long field fail with the following error 

> IOError: File not open for reading

**Case**: cherrypy writes long fields to a temporary file. A custom Southpaw patch opens this temporary file in write-only mode under non-Windows systems, hence it can't be read.

**Solution**: Open the file in write & read mode.