### PR TITLE
fix error handling in remote handler

### DIFF
--- a/src/tactic/protocol/rest_handler.py
+++ b/src/tactic/protocol/rest_handler.py
@@ -158,10 +158,18 @@ class APIRestHandler(BaseRestHandler):
         call = "server.%s(**kwargs)" % method
         print "call: ", call
 
-
-        return eval(call)
-
-
+        try:
+            return eval(call)
+        except Exception as e:
+            import cherrypy
+            cherrypy.response.status = "405"
+            return {
+                "error": {
+                    "args": e.args,
+                    "message": e.message,
+                    "type": e.__class__.__name__
+                }
+            }
 
 
 


### PR DESCRIPTION
* currently if an exception is thrown the stacktrace is send to as response
* so here we parse it and return it as json