### PR TITLE
Fix admin authentication for "non portal" tactic installations

### DIFF
--- a/src/pyasm/security/security.py
+++ b/src/pyasm/security/security.py
@@ -1705,7 +1705,7 @@ class Security(Base):
         site = Site.get_site()
     
         if login_name == 'admin':
-            if site == "default":
+            if site == "" or site == "default":
                 auth_class = "pyasm.security.TacticAuthenticate"
             else:
                 raise SecurityException("Login/Password combination incorrect")


### PR DESCRIPTION
Commit 566ae8f7 broke authentication for "non portal" tactic installations.

This patch solves the problem but I'm not sure how tactic portal works, could this patch break something?