### PR TITLE
Make the queue use the queue param

### DIFF
--- a/src/bin/startup_queue.py
+++ b/src/bin/startup_queue.py
@@ -37,11 +37,11 @@ def main(options, site=None):
     if options.get("mode"):
         os.environ['TACTIC_QUEUE_MODE'] = options.get("mode")
 
-
     JobTask.start(
-            check_interval=0.1,
-            max_jobs_completed=50,
-            pid_path=pid_path,
+        check_interval=0.1,
+        max_jobs_completed=50,
+        pid_path=pid_path,
+        queue=options.get("queue")
     )
 
     try:

--- a/src/pyasm/web/monitor.py
+++ b/src/pyasm/web/monitor.py
@@ -274,6 +274,7 @@ class JobQueueThread(BaseProcessThread):
         self.idx = idx
         self.pid = 0
         self.process_timeout = Config.get_value("services", "queue_process_timeout")
+        self.queue_type = Config.get_value("services", "queue_type")
         if not self.process_timeout:
             self.process_timeout = -1
         else:
@@ -337,6 +338,8 @@ class JobQueueThread(BaseProcessThread):
             "-m",
             "monitor"
         ]
+        if self.queue_type:
+            executable.extend(["-q", self.queue_type])
         self.process = subprocess.Popen(executable)
         self.pid = self.process.pid
 

--- a/src/tactic/command/queue.py
+++ b/src/tactic/command/queue.py
@@ -212,7 +212,7 @@ class JobTask(SchedulerTask):
                 os.utime(pid_path, None)
 
             self.check_existing_jobs()
-            self.check_new_job()
+            self.check_new_job(self.queue_type)
             time.sleep(self.check_interval)
             DbContainer.close_thread_sql()
 


### PR DESCRIPTION
These changes make the queue use the `--queue` param
Also, a new `queue_type` conf key has been added inside `services` so that the queue type can be configured though the conf file and used when running the service with `monitor.py`