### PR TITLE
Changed "Assigned" to "Select a User" when no user is assigned to a task

### DIFF
--- a/src/tactic/ui/table/task_element_wdg.py
+++ b/src/tactic/ui/table/task_element_wdg.py
@@ -2473,7 +2473,7 @@ spt.task_element.status_change_cbk = function(evt, bvr) {
 
                     select.add_class('spt_task_assigned_select')
                     select.add_attr("spt_context", context)
-                    select.add_empty_option('-- Assigned --')
+                    select.add_empty_option('-- Select a User --')
                     select.set_option('values', assignee) 
                     select.set_option('labels', assignee_labels) 
                     select.set_value(assigned)


### PR DESCRIPTION
When no user is assigned to a task the combo box displays "Assigned" which is confusing, changed it to  "Select a User" as it is the same term used in ProcessGroupSelectWdg