### PR TITLE
Re-enabled save button for task status node

### DIFF
--- a/src/tactic/ui/tools/pipeline_wdg.py
+++ b/src/tactic/ui/tools/pipeline_wdg.py
@@ -6018,7 +6018,7 @@ class TaskStatusInfoWdg(BaseInfoWdg):
         settings_wdg.add("<br/>")
 
         save_button = ActionButtonWdg(title="Save", color="primary")
-        settings_wdg.add(save_button)
+        #settings_wdg.add(save_button)
         save_button.add_style("float: right")
         save_button.add_style("padding-top: 3px")
         save_button.add_behavior( {

--- a/src/tactic/ui/tools/pipeline_wdg.py
+++ b/src/tactic/ui/tools/pipeline_wdg.py
@@ -5852,7 +5852,11 @@ class TaskStatusInfoWdg(BaseInfoWdg):
 
         top = self.top
         top.add_class("spt_status_top")
+        top.add_class("spt_section_top")
+
         self.initialize_session_behavior(top)
+
+        SessionalProcess.add_relay_session_behavior(top)
 
         top.add_behavior({
             'type': 'load',
@@ -6080,7 +6084,7 @@ class TaskStatusInfoWdg(BaseInfoWdg):
 
         return {
             "direction": direction,
-            "to_status": to_status,
+            "status": to_status,
             "mapping": mapping
         }
 
@@ -6957,6 +6961,8 @@ class NewProcessInfoCmd(Command):
             self.handle_hierarchy()
         elif node_type == 'progress':
             self.handle_progress()
+        elif node_type == 'status':
+            self.handle_status()
 
 
         # set node workflow data
@@ -7154,12 +7160,23 @@ class NewProcessInfoCmd(Command):
 
     def handle_status(self):
 
-        status_kwargs = self.kwargs.get("status")
+        status_kwargs = self.kwargs.get("default") or {}
+
         color = status_kwargs.get("color")
         if color:
             self.process_sobj.set_value("color", color)
 
+        mapping = status_kwargs.get("mapping")
+        if mapping:
+            self.kwargs['mapping'] = mapping
 
+        direction = status_kwargs.get("direction")
+        if direction:
+            self.kwargs['direction'] = direction
+
+        status = status_kwargs.get("status")
+        if status:
+            self.kwargs['status'] = status
 
 
 class PipelineEditorWdg(BaseRefreshWdg):

--- a/src/tactic/ui/tools/pipeline_wdg.py
+++ b/src/tactic/ui/tools/pipeline_wdg.py
@@ -6018,7 +6018,7 @@ class TaskStatusInfoWdg(BaseInfoWdg):
         settings_wdg.add("<br/>")
 
         save_button = ActionButtonWdg(title="Save", color="primary")
-        #settings_wdg.add(save_button)
+        settings_wdg.add(save_button)
         save_button.add_style("float: right")
         save_button.add_style("padding-top: 3px")
         save_button.add_behavior( {


### PR DESCRIPTION
This button was removed 15 months ago by commit a2aeee14b66b40550992955356546b4c8483dc74 not sure why, but it works and task status nodes can't be saved without it, perhaps at the time some code was not working. If there are any other reasons for the removal please excuse this PR.