### PR TITLE
Allowing disabling printing log for "execute_python_script"

### DIFF
--- a/src/pyasm/prod/service/api_xmlrpc.py
+++ b/src/pyasm/prod/service/api_xmlrpc.py
@@ -241,7 +241,8 @@ def get_full_cmd(self, meth, ticket, args):
             request_id = "%s - #%0.7d" % (thread.get_ident(), REQUEST_COUNT)
 
             debug = True
-            if meth.__name__ == "execute_cmd":
+            debug_args = True
+            if meth.__name__ in ["execute_cmd", "execute_python_script", "execute_js_script"]:
                 #if len(args) > 1:
                 if isinstance(args, tuple) and len(args) > 1:
                     first_arg = args[1]
@@ -252,6 +253,10 @@ def get_full_cmd(self, meth, ticket, args):
                     if _debug == False:
                         debug = False
 
+                    _debug_args = first_arg.get("_debug_args")
+                    if _debug_args == False:
+                        debug_args = False
+
             if self.get_protocol() != "local" and debug:
                 print("---")
                 print("user: ", Environment.get_user_name())
@@ -259,7 +264,8 @@ def get_full_cmd(self, meth, ticket, args):
                 print("timestamp: ", now.strftime("%Y-%m-%d %H:%M:%S"))
                 print("method: ", meth.__name__)
                 print("ticket: ", ticket)
-                Common.pretty_print(args)
+                if debug_args:
+                    Common.pretty_print(args)
             
             #self2.results = meth(self, ticket, *args)
             

--- a/src/tactic/ui/panel/tile_layout_wdg.py
+++ b/src/tactic/ui/panel/tile_layout_wdg.py
@@ -3437,14 +3437,31 @@ class ThumbWdg2(BaseRefreshWdg):
         if not snapshot:
             snapshot = Snapshot.get_snapshot("sthpw/search_object", base_search_type, process=processes)
 
-
         if snapshot:
+
             file_type = "web"
-            icon_path = snapshot.get_web_path_by_type(file_type)
+
+            file_object = snapshot.get_file_by_type(file_type)
+            if file_object:
+                file_name = file_object.get_full_file_name()
+                web_dir = sobject.get_web_dir(snapshot, file_object=file_object)
+
+                icon_path = "%s/%s" % (web_dir, file_name)
+            else:
+                icon_path = snapshot.get_web_path_by_type(file_type)
 
             file_type = "main"
-            main_path = snapshot.get_web_path_by_type(file_type)
+
             lib_path = snapshot.get_lib_path_by_type(file_type)
+
+            file_object = snapshot.get_file_by_type(file_type)
+            if file_object:
+                file_name = file_object.get_full_file_name()
+                web_dir = sobject.get_web_dir(snapshot, file_object=file_object)
+
+                main_path = "%s/%s" % (web_dir, file_name)
+            else:
+                main_path = snapshot.get_web_path_by_type(file_type)
 
         if icon_path:
             path = icon_path


### PR DESCRIPTION
Executing lots of execute_python_script or execute_js_script filling log with dumb data. If one want see some logs he already can print in executing method, so loggin this all time become useless and fill logs with gigs of duplicated text.