### PR TITLE
Added security check for gear menu in index page

### DIFF
--- a/src/tactic/ui/bootstrap_app/bootstrap_index_wdg.py
+++ b/src/tactic/ui/bootstrap_app/bootstrap_index_wdg.py
@@ -919,8 +919,10 @@ class BootstrapTopNavWdg(BaseRefreshWdg, PageHeaderWdg):
         project_select_wdg = BootstrapProjectSelectWdg()
         button_row.add(project_select_wdg)
 
-        gear_menu_wdg = BootstrapIndexGearMenuWdg()
-        button_row.add(gear_menu_wdg)
+        security = Environment.get_security()
+        if security.check_access("builtin", "index_gear_menu", "allow"):
+            gear_menu_wdg = BootstrapIndexGearMenuWdg()
+            button_row.add(gear_menu_wdg)
 
         user_wdg = self.get_user_wdg()
         right_wdg.add(user_wdg)


### PR DESCRIPTION
Hi Remko, I send this commit as a separate PR in case you want to reject it.

I feel the Gear menu in the index page has some functionalities I don't want to be exposed to some groups (ie Add subject menu and undo/redo transaction logs), the only problem is that will hide the menu if it is not explicitly allowed potentially changing existing installations behaviour.