### PR TITLE
Pipeline Task creation trigger fixes

### DIFF
--- a/src/tactic/command/pipeline_task_trigger.py
+++ b/src/tactic/command/pipeline_task_trigger.py
@@ -478,15 +478,6 @@ class PipelineTaskCreateTrigger(Trigger):
         if not process_names:
             return
 
-        # only create new task if another of the same
-        # process does not already exist
-        search = Search("sthpw/task")
-        search.add_filters("process", process_names)
-        search.add_parent_filter(parent)
-        search.add_project_filter()
-        tasks = search.get_sobjects()
-        existing_processes = [x.get_value("process") for x in tasks]
-        
         Task.add_initial_tasks(parent, parent.get_value('pipeline_code'), processes=process_names,
                                contexts=process_names, skip_duplicate=True, mode='standard', start_offset=0)
 

--- a/src/tactic/command/pipeline_task_trigger.py
+++ b/src/tactic/command/pipeline_task_trigger.py
@@ -486,13 +486,10 @@ class PipelineTaskCreateTrigger(Trigger):
         search.add_project_filter()
         tasks = search.get_sobjects()
         existing_processes = [x.get_value("process") for x in tasks]
-       
-        for process in process_names:
-            if process in existing_processes:    
-                continue
-            else:
-                Task.create(parent, process, start_date=None, end_date=None)
-          
+        
+        Task.add_initial_tasks(parent, parent.get_value('pipeline_code'), processes=process_names,
+                               contexts=process_names, skip_duplicate=True, mode='standard', start_offset=0)
+
 
 
 

--- a/src/tactic/ui/tools/trigger_wdg.py
+++ b/src/tactic/ui/tools/trigger_wdg.py
@@ -1791,7 +1791,7 @@ class TriggerCreateCbk(BaseTriggerEditCbk):
     def execute(self):
 
         outputs = self.kwargs.get("output")
-        if isinstance(outputs, basestring) and outputs:
+        if isinstance(outputs, str) and outputs:
             outputs = [outputs]
         elif isinstance(outputs, list):
             outputs = [p for p in outputs if p]


### PR DESCRIPTION
- py3 fix
- added initial task instead of default task creation because it ignores pipeline settings when creating task