### PR TITLE
simple_checkin argument mode.

### DIFF
--- a/src/client/tactic_client_lib/tactic_server_stub.py
+++ b/src/client/tactic_client_lib/tactic_server_stub.py
@@ -1980,7 +1980,7 @@ class TacticServerStub(object):
     def simple_checkin(self, search_key, context, file_path,
             snapshot_type="file", description="No description",
             use_handoff_dir=False, file_type="main", is_current=True,
-            level_key=None, breadcrumb=False, metadata={}, mode='upload',
+            level_key=None, breadcrumb=False, metadata={}, mode=None,
             is_revision=False, info={} ,
             keep_file_name=False, create_icon=True, 
             checkin_cls='pyasm.checkin.FileCheckin',


### PR DESCRIPTION
simple_checkin argument mode set to None in tactic_server_stub because the default mode is already set as "uploaded" if not set explicitly in the function.