### PR TITLE
Fixing versionless link file read error on Windows

### DIFF
--- a/src/pyasm/search/transaction.py
+++ b/src/pyasm/search/transaction.py
@@ -729,7 +729,7 @@ class FileUndo:
             # check the link file
 
             if os.path.exists(link_path):
-                link_file = open(link_path, "rb")
+                link_file = open(link_path, "r")
                 prev = link_file.readline()
                 link_file.close()
                 extra['prev'] = Common.relative_path(asset_dir, prev)

--- a/src/pyasm/security/__init__.py
+++ b/src/pyasm/security/__init__.py
@@ -17,5 +17,5 @@ from .access_manager import *
 from .batch import *
 from .access_rule import *
 from .drupal_password_hasher import *
-#from .ldap_ad_authenticate import *
+from .ldap_ad_authenticate import *
 from .external_service import *


### PR DESCRIPTION
When you create versionless naming entries on `Windows` with `python3`, an error is thrown on `server.add_file` on the corresponding snapshot. This is due to the fact that we are opening "link" files as binaries and comparing the content with unicode literals.

File "pyasm\common\common.py", line 359, in relative_dir
    TypeError: endswith first arg must be bytes or a tuple of bytes, not str