### PR TITLE
Introducing #! to client side bin scripts

### DIFF
--- a/src/client/bin/create_project.py
+++ b/src/client/bin/create_project.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 ###########################################################
 #
 # Copyright (c) 2005, Southpaw Technology

--- a/src/client/bin/get_ticket.py
+++ b/src/client/bin/get_ticket.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 ###########################################################
 #
 # Copyright (c) 2005, Southpaw Technology


### PR DESCRIPTION
The Repository [tactic-client](https://github.com/rvanlaar/tactic-client) enables installation of the tactic_client_lib through Pypi, and deploys the client side shell scripts `create_ticket.py` and `create_project.py` to the python `scripts` or `bin` directory. 

The lack of a shebang directive on top of the file cause bash to throw errors, when executed directly from the shell.