### PR TITLE
Fix security bug, a normal user could query sensitive tables via API (see issue #1694)

### DIFF
--- a/src/pyasm/search/search.py
+++ b/src/pyasm/search/search.py
@@ -261,9 +261,6 @@ class Search(Base):
         search_type = self.get_base_search_type()
         api_mode = Environment.get_api_mode()
 
-        if api_mode in ['open', '', None]:
-            return
-
         # Commented our for testing
         if user in ['admin']:
             return
@@ -285,6 +282,8 @@ class Search(Base):
         }:
             raise Exception("Search Permission Denied [%s]" % search_type)
 
+        if api_mode in ['open', '', None]:
+            return
 
 
 


### PR DESCRIPTION
a normal user could query sensitive tables via API, for example acquire other user login tickets by querying sthpw/ticket.
The pass if api_mode is open should be done after checking the query is not on security sensitive tables